### PR TITLE
Handle SIGTERM gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "clap",
  "env_logger",
  "flate2",
+ "futures",
  "log",
  "nix",
  "oci-distribution",

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1"
 thiserror = "1"
 clap = { version = "4", features = ["derive"]}
 aya = "0.11"
-tokio = { version = "1.27.0", features = ["full"] }
+tokio = { version = "1.27.0", features = ["full", "signal"] }
 uuid = { version = "1", features = ["v4"] }
 log = "0.4"
 env_logger = "0.10"
@@ -41,3 +41,4 @@ tokio-stream = { version = "0.1.12", features = ["net"] }
 sha2 = "0.10.6"
 base16ct = { version = "0.2.0", features = ["alloc"] }
 tempfile = "3.4.0"
+futures = "0.3.27"

--- a/bpfd/src/lib.rs
+++ b/bpfd/src/lib.rs
@@ -28,7 +28,7 @@ use tokio::{
     net::UnixListener,
     select,
     signal::unix::{signal, SignalKind},
-    sync::mpsc,
+    sync::{mpsc, watch},
 };
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::{Server, ServerTlsConfig};
@@ -106,6 +106,7 @@ pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<
         }
     }));
 
+    let (shutdown_tx, mut shutdown_rx) = watch::channel(());
     task_handles.push(tokio::spawn(async move {
         let mut sigint = signal(SignalKind::interrupt()).unwrap();
         let mut sigterm = signal(SignalKind::terminate()).unwrap();
@@ -114,9 +115,7 @@ pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<
             _ = sigterm.recv() => {debug!("Received SIGTERM")},
         }
 
-        for handle in shutdown_senders {
-            handle.send(()).unwrap_or_default();
-        }
+        shutdown_tx.send(()).unwrap();
     }));
 
     let mut bpf_manager = BpfManager::new(&config);
@@ -132,156 +131,168 @@ pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<
         }
     };
 
-    // Start receiving messages
-    while let Some(cmd) = rx.recv().await {
-        match cmd {
-            Command::LoadXDP {
-                location,
-                section_name,
-                id,
-                global_data,
-                iface,
-                priority,
-                proceed_on,
-                username,
-                responder,
-            } => {
-                let res = if let Ok(if_index) = get_ifindex(&iface) {
-                    let prog_data =
-                        ProgramData::new(location, section_name.clone(), global_data, username)
-                            .await?;
+    loop {
+        select! {
+            biased;
 
-                    let prog_result = Ok(Program::Xdp(XdpProgram {
-                        data: prog_data.clone(),
-                        info: XdpProgramInfo {
-                            if_index,
-                            current_position: None,
-                            metadata: command::Metadata {
-                                priority,
-                                // This could have been overridden by image tags
-                                name: prog_data.section_name,
-                                attached: false,
-                            },
-                            proceed_on,
-                            if_name: iface,
-                        },
-                    }));
+            _ = shutdown_rx.changed() => break,
 
-                    match prog_result {
-                        Ok(prog) => bpf_manager.add_program(prog, id).await,
-                        Err(e) => Err(e),
+            // Start receiving messages
+            Some(cmd) = rx.recv() => {
+                match cmd {
+                    Command::LoadXDP {
+                        location,
+                        section_name,
+                        id,
+                        global_data,
+                        iface,
+                        priority,
+                        proceed_on,
+                        username,
+                        responder,
+                    } => {
+                        let res = if let Ok(if_index) = get_ifindex(&iface) {
+                            let prog_data =
+                                ProgramData::new(location, section_name.clone(), global_data, username)
+                                    .await?;
+
+                            let prog_result = Ok(Program::Xdp(XdpProgram {
+                                data: prog_data.clone(),
+                                info: XdpProgramInfo {
+                                    if_index,
+                                    current_position: None,
+                                    metadata: command::Metadata {
+                                        priority,
+                                        // This could have been overridden by image tags
+                                        name: prog_data.section_name,
+                                        attached: false,
+                                    },
+                                    proceed_on,
+                                    if_name: iface,
+                                },
+                            }));
+
+                            match prog_result {
+                                Ok(prog) => bpf_manager.add_program(prog, id).await,
+                                Err(e) => Err(e),
+                            }
+                        } else {
+                            Err(BpfdError::InvalidInterface)
+                        };
+
+                        // If program was successfully loaded, allow map access by bpfd group members.
+                        if let Ok(uuid) = &res {
+                            let maps_dir = format!("{RTDIR_FS_MAPS}/{uuid}");
+                            set_dir_permissions(&maps_dir, MAPS_MODE).await;
+                        }
+
+                        // Ignore errors as they'll be propagated to caller in the RPC status
+                        let _ = responder.send(res);
                     }
-                } else {
-                    Err(BpfdError::InvalidInterface)
-                };
-
-                // If program was successfully loaded, allow map access by bpfd group members.
-                if let Ok(uuid) = &res {
-                    let maps_dir = format!("{RTDIR_FS_MAPS}/{uuid}");
-                    set_dir_permissions(&maps_dir, MAPS_MODE).await;
-                }
-
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(res);
-            }
-            Command::LoadTC {
-                location,
-                section_name,
-                id,
-                global_data,
-                iface,
-                priority,
-                direction,
-                proceed_on,
-                username,
-                responder,
-            } => {
-                let res = if let Ok(if_index) = get_ifindex(&iface) {
-                    let prog_data =
-                        ProgramData::new(location, section_name, global_data, username).await?;
-
-                    let prog_result = Ok(Program::Tc(TcProgram {
-                        data: prog_data.clone(),
+                    Command::LoadTC {
+                        location,
+                        section_name,
+                        id,
+                        global_data,
+                        iface,
+                        priority,
                         direction,
-                        info: TcProgramInfo {
-                            if_index,
-                            current_position: None,
-                            metadata: command::Metadata {
-                                priority,
-                                // This could have been overridden by image tags
-                                name: prog_data.section_name,
-                                attached: false,
-                            },
-                            proceed_on,
-                            if_name: iface,
-                        },
-                    }));
+                        proceed_on,
+                        username,
+                        responder,
+                    } => {
+                        let res = if let Ok(if_index) = get_ifindex(&iface) {
+                            let prog_data =
+                                ProgramData::new(location, section_name, global_data, username).await?;
 
-                    match prog_result {
-                        Ok(prog) => bpf_manager.add_program(prog, id).await,
-                        Err(e) => Err(e),
+                            let prog_result = Ok(Program::Tc(TcProgram {
+                                data: prog_data.clone(),
+                                direction,
+                                info: TcProgramInfo {
+                                    if_index,
+                                    current_position: None,
+                                    metadata: command::Metadata {
+                                        priority,
+                                        // This could have been overridden by image tags
+                                        name: prog_data.section_name,
+                                        attached: false,
+                                    },
+                                    proceed_on,
+                                    if_name: iface,
+                                },
+                            }));
+
+                            match prog_result {
+                                Ok(prog) => bpf_manager.add_program(prog, id).await,
+                                Err(e) => Err(e),
+                            }
+                        } else {
+                            Err(BpfdError::InvalidInterface)
+                        };
+
+                        // If program was successfully loaded, allow map access by bpfd group members.
+                        if let Ok(uuid) = &res {
+                            let maps_dir = format!("{RTDIR_FS_MAPS}/{}", uuid.clone());
+                            set_dir_permissions(&maps_dir, MAPS_MODE).await;
+                        }
+
+                        // Ignore errors as they'll be propagated to caller in the RPC status
+                        let _ = responder.send(res);
                     }
-                } else {
-                    Err(BpfdError::InvalidInterface)
-                };
+                    Command::LoadTracepoint {
+                        location,
+                        section_name,
+                        id,
+                        global_data,
+                        tracepoint,
+                        username,
+                        responder,
+                    } => {
+                        let res = {
+                            let prog_data =
+                                ProgramData::new(location, section_name, global_data, username).await?;
 
-                // If program was successfully loaded, allow map access by bpfd group members.
-                if let Ok(uuid) = &res {
-                    let maps_dir = format!("{RTDIR_FS_MAPS}/{}", uuid.clone());
-                    set_dir_permissions(&maps_dir, MAPS_MODE).await;
-                }
+                            let prog_result = Ok(Program::Tracepoint(TracepointProgram {
+                                data: prog_data,
+                                info: TracepointProgramInfo { tracepoint },
+                            }));
 
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(res);
-            }
-            Command::LoadTracepoint {
-                location,
-                section_name,
-                id,
-                global_data,
-                tracepoint,
-                username,
-                responder,
-            } => {
-                let res = {
-                    let prog_data =
-                        ProgramData::new(location, section_name, global_data, username).await?;
+                            match prog_result {
+                                Ok(prog) => bpf_manager.add_program(prog, id).await,
+                                Err(e) => Err(e),
+                            }
+                        };
 
-                    let prog_result = Ok(Program::Tracepoint(TracepointProgram {
-                        data: prog_data,
-                        info: TracepointProgramInfo { tracepoint },
-                    }));
+                        // If program was successfully loaded, allow map access by bpfd group members.
+                        if let Ok(uuid) = &res {
+                            let maps_dir = format!("{RTDIR_FS_MAPS}/{uuid}");
+                            set_dir_permissions(&maps_dir, MAPS_MODE).await;
+                        }
 
-                    match prog_result {
-                        Ok(prog) => bpf_manager.add_program(prog, id).await,
-                        Err(e) => Err(e),
+                        // Ignore errors as they'll be propagated to caller in the RPC status
+                        let _ = responder.send(res);
                     }
-                };
-
-                // If program was successfully loaded, allow map access by bpfd group members.
-                if let Ok(uuid) = &res {
-                    let maps_dir = format!("{RTDIR_FS_MAPS}/{uuid}");
-                    set_dir_permissions(&maps_dir, MAPS_MODE).await;
+                    Command::Unload {
+                        id,
+                        username,
+                        responder,
+                    } => {
+                        let res = bpf_manager.remove_program(id, username).await;
+                        // Ignore errors as they'll be propagated to caller in the RPC status
+                        let _ = responder.send(res);
+                    }
+                    Command::List { responder } => {
+                        let progs = bpf_manager.list_programs();
+                        // Ignore errors as they'll be propagated to caller in the RPC status
+                        let _ = responder.send(progs);
+                    }
                 }
-
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(res);
-            }
-            Command::Unload {
-                id,
-                username,
-                responder,
-            } => {
-                let res = bpf_manager.remove_program(id, username).await;
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(res);
-            }
-            Command::List { responder } => {
-                let progs = bpf_manager.list_programs();
-                // Ignore errors as they'll be propagated to caller in the RPC status
-                let _ = responder.send(progs);
             }
         }
+    }
+
+    for handle in shutdown_senders {
+        handle.send(()).unwrap_or_default();
     }
 
     for handle in task_handles {


### PR DESCRIPTION
A new tokio task is spawned and set to wait for both SIGTERM and SIGINT. When either of these signals is received a message on a oneshot channel is issued to trigger the tonic service to shutdown, which in turn also makes the main loop exit and cleanly stops bpfd.

Fixes #175

