### PR TITLE
Add Action to put all issues in project

### DIFF
--- a/.github/workflows/put-issue-in-project.yaml
+++ b/.github/workflows/put-issue-in-project.yaml
@@ -1,0 +1,18 @@
+name: Add all issues to bpfd project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          # You can target a project in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/bpfd-dev/projects/4
+          github-token: ${{ secrets.BPFD_PROJECT_PAT }}


### PR DESCRIPTION
In order to manage our issues from a single pane of glass it makes sense to have a bot simply triage all issues into our bpfd project.
