### PR TITLE
bpfd: Fix UUID Validation

### DIFF
--- a/bpfd-operator/controllers/bpfd-agent/tc-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program.go
@@ -18,7 +18,10 @@ package bpfdagent
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
+	"math/rand"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -186,7 +189,17 @@ func (r *TcProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 
 	for _, iface := range ifaces {
 		loadRequest := &gobpfd.LoadRequest{}
-		id := uuid.New().String()
+
+		// Hash this string and use it as seed to make the UUID deterministic
+		// for now. Eventually the BpfProgram UID will be used for this.
+		h := sha256.New()
+		h.Write([]byte(fmt.Sprintf("%s-%s", TcProgram.Name, iface)))
+		seed := binary.BigEndian.Uint64(h.Sum(nil))
+		rnd := rand.New(rand.NewSource(int64(seed)))
+		uuid.SetRand(rnd)
+		uuid, _ := uuid.NewRandomFromReader(rnd)
+		id := uuid.String()
+
 		loadRequest.Common = bpfdagentinternal.BuildBpfdCommon(bytecode, TcProgram.Spec.SectionName, internal.Tc, id, TcProgram.Spec.GlobalData)
 
 		loadRequest.AttachInfo = &gobpfd.LoadRequest_TcAttachInfo{

--- a/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
@@ -33,6 +33,7 @@ import (
 
 	bpfdiov1alpha1 "github.com/bpfd-dev/bpfd/bpfd-operator/apis/v1alpha1"
 	bpfdagentinternal "github.com/bpfd-dev/bpfd/bpfd-operator/controllers/bpfd-agent/internal"
+	"github.com/google/uuid"
 
 	internal "github.com/bpfd-dev/bpfd/bpfd-operator/internal"
 
@@ -146,9 +147,8 @@ func (r *TracePointProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 	}
 
 	loadRequest := &gobpfd.LoadRequest{}
-
-	Id := tracepointProgram.Name
-	loadRequest.Common = bpfdagentinternal.BuildBpfdCommon(bytecode, tracepointProgram.Spec.SectionName, internal.Tracepoint, Id, tracepointProgram.Spec.GlobalData)
+	id := uuid.New().String()
+	loadRequest.Common = bpfdagentinternal.BuildBpfdCommon(bytecode, tracepointProgram.Spec.SectionName, internal.Tracepoint, id, tracepointProgram.Spec.GlobalData)
 
 	loadRequest.AttachInfo = &gobpfd.LoadRequest_TracepointAttachInfo{
 		TracepointAttachInfo: &gobpfd.TracepointAttachInfo{
@@ -156,7 +156,7 @@ func (r *TracePointProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 		},
 	}
 
-	existingProgram, doesProgramExist := existingBpfPrograms[Id]
+	existingProgram, doesProgramExist := existingBpfPrograms[id]
 	if !doesProgramExist {
 		r.Logger.V(1).Info("TracepointProgram doesn't exist on node")
 
@@ -177,7 +177,7 @@ func (r *TracePointProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 			return BpfProgCondNotLoaded, err
 		}
 
-		r.expectedPrograms[Id] = bpfProgramEntry
+		r.expectedPrograms[id] = bpfProgramEntry
 
 		return BpfProgCondLoaded, nil
 	}
@@ -187,11 +187,11 @@ func (r *TracePointProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 	if !tracepointProgram.DeletionTimestamp.IsZero() || !isNodeSelected {
 		r.Logger.V(1).Info("TcProgram exists on Node but is scheduled for deletion or node is no longer selected", "isDeleted", !tracepointProgram.DeletionTimestamp.IsZero(),
 			"isSelected", isNodeSelected)
-		if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, Id); err != nil {
+		if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, id); err != nil {
 			r.Logger.Error(err, "Failed to unload TcProgram")
 			return BpfProgCondLoaded, err
 		}
-		delete(r.expectedPrograms, Id)
+		delete(r.expectedPrograms, id)
 
 		// continue to next program
 		return BpfProgCondNotSelected, nil
@@ -200,7 +200,7 @@ func (r *TracePointProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 	r.Logger.V(1).WithValues("expectedProgram", loadRequest).WithValues("existingProgram", existingProgram).Info("StateMatch")
 	// BpfProgram exists but is not correct state, unload and recreate
 	if !bpfdagentinternal.DoesProgExist(existingProgram, loadRequest) {
-		if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, Id); err != nil {
+		if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, id); err != nil {
 			r.Logger.Error(err, "Failed to unload TcProgram")
 			return BpfProgCondNotUnloaded, err
 		}
@@ -211,17 +211,17 @@ func (r *TracePointProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 			return BpfProgCondNotLoaded, err
 		}
 
-		r.expectedPrograms[Id] = bpfProgramEntry
+		r.expectedPrograms[id] = bpfProgramEntry
 	} else {
 		// Program already exists, but bpfProgram K8s Object might not be up to date
-		if _, ok := r.bpfProgram.Spec.Programs[Id]; !ok {
-			maps, err := bpfdagentinternal.GetMapsForUUID(Id)
+		if _, ok := r.bpfProgram.Spec.Programs[id]; !ok {
+			maps, err := bpfdagentinternal.GetMapsForUUID(id)
 			if err != nil {
 				r.Logger.Error(err, "failed to get bpfProgram's Maps")
 				return BpfProgCondNotLoaded, err
 			}
 
-			r.expectedPrograms[Id] = maps
+			r.expectedPrograms[id] = maps
 		} else {
 			// Program exists and bpfProgram K8s Object is up to date
 			r.Logger.V(1).Info("Ignoring Object Change nothing to do in bpfd")

--- a/bpfd/src/command.rs
+++ b/bpfd/src/command.rs
@@ -10,6 +10,7 @@ use bpfd_api::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
+use uuid::Uuid;
 
 use crate::{
     errors::BpfdError,
@@ -29,39 +30,39 @@ pub(crate) enum Command {
     LoadXDP {
         location: Location,
         section_name: String,
-        id: Option<String>,
+        id: Option<Uuid>,
         global_data: HashMap<String, Vec<u8>>,
         iface: String,
         priority: i32,
         proceed_on: XdpProceedOn,
         username: String,
-        responder: Responder<Result<String, BpfdError>>,
+        responder: Responder<Result<Uuid, BpfdError>>,
     },
     /// Load a TC Program
     LoadTC {
         location: Location,
         section_name: String,
-        id: Option<String>,
+        id: Option<Uuid>,
         global_data: HashMap<String, Vec<u8>>,
         iface: String,
         priority: i32,
         direction: Direction,
         proceed_on: TcProceedOn,
         username: String,
-        responder: Responder<Result<String, BpfdError>>,
+        responder: Responder<Result<Uuid, BpfdError>>,
     },
     // Load a Tracepoint Program
     LoadTracepoint {
         location: Location,
-        id: Option<String>,
+        id: Option<Uuid>,
         section_name: String,
         global_data: HashMap<String, Vec<u8>>,
         tracepoint: String,
         username: String,
-        responder: Responder<Result<String, BpfdError>>,
+        responder: Responder<Result<Uuid, BpfdError>>,
     },
     Unload {
-        id: String,
+        id: Uuid,
         username: String,
         responder: Responder<Result<(), BpfdError>>,
     },
@@ -107,7 +108,7 @@ impl std::fmt::Display for Direction {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ProgramInfo {
-    pub(crate) id: String,
+    pub(crate) id: Uuid,
     pub(crate) name: String,
     pub(crate) location: Location,
     pub(crate) program_type: i32,
@@ -337,13 +338,13 @@ impl Program {
         }
     }
 
-    pub(crate) fn save(&self, uuid: String) -> Result<(), anyhow::Error> {
+    pub(crate) fn save(&self, uuid: Uuid) -> Result<(), anyhow::Error> {
         let path = format!("{RTDIR_PROGRAMS}/{uuid}");
         serde_json::to_writer(&fs::File::create(path)?, &self)?;
         Ok(())
     }
 
-    pub(crate) fn delete(&self, uuid: String) -> Result<(), anyhow::Error> {
+    pub(crate) fn delete(&self, uuid: Uuid) -> Result<(), anyhow::Error> {
         let path = format!("{RTDIR_PROGRAMS}/{uuid}");
         fs::remove_file(path)?;
 
@@ -360,7 +361,7 @@ impl Program {
         Ok(())
     }
 
-    pub(crate) fn load(uuid: String) -> Result<Self, anyhow::Error> {
+    pub(crate) fn load(uuid: Uuid) -> Result<Self, anyhow::Error> {
         let path = format!("{RTDIR_PROGRAMS}/{uuid}");
         let file = fs::File::open(path)?;
         let reader = BufReader::new(file);

--- a/bpfd/src/errors.rs
+++ b/bpfd/src/errors.rs
@@ -2,6 +2,7 @@
 // Copyright Authors of bpfd
 
 use thiserror::Error;
+use uuid::Uuid;
 
 #[derive(Debug, Error)]
 pub enum BpfdError {
@@ -41,5 +42,5 @@ pub enum BpfdError {
     #[error("Unable to parse passed UUID {0}")]
     PassedUUIDError(#[from] uuid::Error),
     #[error("Passed UUID already in use {0}")]
-    PassedUUIDInUse(String),
+    PassedUUIDInUse(Uuid),
 }

--- a/bpfd/src/multiprog/mod.rs
+++ b/bpfd/src/multiprog/mod.rs
@@ -10,6 +10,7 @@ use bpfd_api::{
 };
 use log::debug;
 pub use tc::TcDispatcher;
+use uuid::Uuid;
 pub use xdp::XdpDispatcher;
 
 use crate::{
@@ -25,7 +26,7 @@ pub(crate) enum Dispatcher {
 impl Dispatcher {
     pub fn new(
         config: Option<&InterfaceConfig>,
-        programs: &[(String, Program)],
+        programs: &[(Uuid, Program)],
         revision: u32,
         old_dispatcher: Option<Dispatcher>,
     ) -> Result<Dispatcher, BpfdError> {

--- a/bpfd/src/multiprog/tc.rs
+++ b/bpfd/src/multiprog/tc.rs
@@ -16,6 +16,7 @@ use bpfd_api::util::directories::*;
 use bpfd_common::TcDispatcherConfig;
 use log::debug;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use super::Dispatcher;
 use crate::{
@@ -54,12 +55,12 @@ impl TcDispatcher {
         direction: Direction,
         if_index: &u32,
         if_name: String,
-        programs: &[(String, Program)],
+        programs: &[(Uuid, Program)],
         revision: u32,
         old_dispatcher: Option<Dispatcher>,
     ) -> Result<TcDispatcher, BpfdError> {
         debug!("TcDispatcher::new() for if_index {if_index}, revision {revision}");
-        let mut extensions: Vec<(&String, &TcProgram)> = programs
+        let mut extensions: Vec<(&Uuid, &TcProgram)> = programs
             .iter()
             .filter_map(|(k, v)| match v {
                 Program::Tc(p) => Some((k, p)),
@@ -160,7 +161,7 @@ impl TcDispatcher {
 
     fn attach_extensions(
         &mut self,
-        extensions: &mut [(&String, &TcProgram)],
+        extensions: &mut [(&Uuid, &TcProgram)],
     ) -> Result<(), BpfdError> {
         debug!(
             "TcDispatcher::attach_extensions() for if_index {}, revision {}",

--- a/bpfd/src/multiprog/xdp.rs
+++ b/bpfd/src/multiprog/xdp.rs
@@ -15,6 +15,7 @@ use bpfd_api::{config::XdpMode, util::directories::*};
 use bpfd_common::XdpDispatcherConfig;
 use log::debug;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use super::Dispatcher;
 use crate::{
@@ -44,12 +45,12 @@ impl XdpDispatcher {
         mode: XdpMode,
         if_index: &u32,
         if_name: String,
-        programs: &[(String, Program)],
+        programs: &[(Uuid, Program)],
         revision: u32,
         old_dispatcher: Option<Dispatcher>,
     ) -> Result<XdpDispatcher, BpfdError> {
         debug!("XdpDispatcher::new() for if_index {if_index}, revision {revision}");
-        let mut extensions: Vec<(&String, &XdpProgram)> = programs
+        let mut extensions: Vec<(&Uuid, &XdpProgram)> = programs
             .iter()
             .filter_map(|(k, v)| match v {
                 Program::Xdp(p) => Some((k, p)),
@@ -136,7 +137,7 @@ impl XdpDispatcher {
 
     fn attach_extensions(
         &mut self,
-        extensions: &mut [(&String, &XdpProgram)],
+        extensions: &mut [(&Uuid, &XdpProgram)],
     ) -> Result<(), BpfdError> {
         debug!(
             "XdpDispatcher::attach_extensions() for if_index {}, revision {}",


### PR DESCRIPTION
This reverts parts of the 624b991 that changed bpfd's internal ID from UUID to String, which therefore removed UUID validation.

UUIDs coming over gRPC are String, since using a byte-based encoding might not be the easiest thing to use in all potential client languages.

However, once received from gRPC, UUIDs should be stored in UUID format, and any parsing failures should be returned to the caller.