### PR TITLE
With openssl bump to 0.10.52, tls broken

### DIFF
--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -34,7 +34,7 @@ oci-distribution = {version = "0.9", default-features = false, features = ["rust
 serde_json = "1.0"
 tar = "0.4"
 flate2 = "1.0"
-openssl = { version = "0.10.47", features = ["vendored"] }
+openssl = { version = "0.10.52", features = ["vendored"] }
 url = "2.3.1"
 users = "0.11.0"
 tokio-stream = { version = "0.1.12", features = ["net"] }

--- a/bpfd/src/certs.rs
+++ b/bpfd/src/certs.rs
@@ -262,6 +262,7 @@ async fn generate_cert(
 
     let subject_alt_name = SubjectAlternativeName::new()
         .dns("localhost,IP:127.0.0.1")
+        .dns("localhost")
         .build(&cert_builder.x509v3_context(Some(&ca_cert_x590), None))?;
     cert_builder.append_extension(subject_alt_name)?;
 


### PR DESCRIPTION
Connection to bpfd over TLS broken with the bump to openssl 0.10.52.

$ ./go-xdp-counter -iface vethdd340d3
2023/04/28 08:18:24 Using Input: Interface=vethdd340d3 Priority=50 Source=0xc000548670 2023/04/28 08:18:24 Reading /etc/bpfd/gocounter.toml ... 2023/04/28 08:18:24 Read /etc/bpfd/gocounter.toml failed: err open /etc/bpfd/gocounter.toml: no such file or directory 2023/04/28 08:18:24 rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: failed to verify certificate: x509: certificate is valid for localhost,IP:127.0.0.1, not localhost"

NOTE: openssl was bumped in the Cargo.lock file, but wasn't bumped in bpfd/Cargo.toml,
      so bumped in toml file as well.