### PR TITLE
bpfctl is retrying failed operations over TCP

### DIFF
--- a/bpfctl/src/main.rs
+++ b/bpfctl/src/main.rs
@@ -200,7 +200,10 @@ async fn main() -> anyhow::Result<()> {
             info!("Using UNIX socket as transport");
             match execute_request(&cli.command, channel).await {
                 Ok(_) => return Ok(()),
-                Err(e) => eprintln!("Error = {e:?}"),
+                Err(e) => {
+                    eprintln!("Error = {e:?}");
+                    return Ok(());
+                }
             }
         }
         Err(e) => debug!("Error getting UNIX socket channel. Err: {}", e),


### PR DESCRIPTION
With the addition of Unix Sockets, there was a missing return statement when an error was encountered when trying over socket.

Resolves: #447