### PR TITLE
Finish implementing support for TC proceed-on

### DIFF
--- a/bpfd-ebpf/src/bpf/tc_dispatcher.bpf.c
+++ b/bpfd-ebpf/src/bpf/tc_dispatcher.bpf.c
@@ -9,7 +9,7 @@
 
 #define TC_METADATA_SECTION "tc_metadata"
 #define TC_DISPATCHER_VERSION 1
-#define TC_DISPATCHER_RETVAL TC_ACT_OK
+#define TC_DISPATCHER_RETVAL 30
 #define MAX_DISPATCHER_ACTIONS 10
 
 struct tc_dispatcher_config {
@@ -127,61 +127,61 @@ int tc_dispatcher(struct __sk_buff *skb)
 	if (num_progs_enabled < 1)
 		goto out;
 	ret = prog0(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[0]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[0]))
 		return ret;
 
 	if (num_progs_enabled < 2)
 		goto out;
 	ret = prog1(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[1]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[1]))
 		return ret;
 
 	if (num_progs_enabled < 3)
 		goto out;
 	ret = prog2(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[2]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[2]))
 		return ret;
 
 	if (num_progs_enabled < 4)
 		goto out;
 	ret = prog3(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[3]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[3]))
 		return ret;
 
 	if (num_progs_enabled < 5)
 		goto out;
 	ret = prog4(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[4]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[4]))
 		return ret;
 
 	if (num_progs_enabled < 6)
 		goto out;
 	ret = prog5(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[5]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[5]))
 		return ret;
 
 	if (num_progs_enabled < 7)
 		goto out;
 	ret = prog6(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[6]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[6]))
 		return ret;
 
 	if (num_progs_enabled < 8)
 		goto out;
 	ret = prog7(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[7]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[7]))
 		return ret;
 
 	if (num_progs_enabled < 9)
 		goto out;
 	ret = prog8(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[8]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[8]))
 		return ret;
 
 	if (num_progs_enabled < 10)
 		goto out;
 	ret = prog9(skb);
-	if (!((1U << ret) & CONFIG.chain_call_actions[9]))
+	if (!((1U << (ret + 1)) & CONFIG.chain_call_actions[9]))
 		return ret;
 
 	/* keep a reference to the compat_test() function so we can use it

--- a/bpfd-operator/controllers/bpfd-agent/tc-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program.go
@@ -91,7 +91,7 @@ func tcProceedOnToInt(proceedOn []bpfdiov1alpha1.TcProceedOnValue) []int32 {
 		case "trap":
 			out = append(out, 8)
 		case "dispatcher_return":
-			out = append(out, 31)
+			out = append(out, 30)
 		}
 	}
 

--- a/bpfd/src/bpf.rs
+++ b/bpfd/src/bpf.rs
@@ -8,7 +8,7 @@ use aya::{
     programs::{links::FdLink, trace_point::TracePointLink, TracePoint},
     BpfLoader,
 };
-use bpfd_api::{config::Config, util::directories::*, ProgramType, TcProceedOn};
+use bpfd_api::{config::Config, util::directories::*, ProgramType};
 use log::debug;
 use uuid::Uuid;
 
@@ -491,7 +491,7 @@ impl<'a> BpfManager<'a> {
                     attach_info: crate::command::AttachInfo::Tc(crate::command::TcAttachInfo {
                         iface: p.info.if_name.to_string(),
                         priority: p.info.metadata.priority,
-                        proceed_on: TcProceedOn::default(),
+                        proceed_on: p.info.proceed_on.clone(),
                         direction: p.direction,
                         position: p.info.current_position.unwrap_or_default() as i32,
                     }),


### PR DESCRIPTION
Fixes  issue #299.

A key point to understand about this implementation the following:

Valid TC return values range from -1 to 8.  Since -1 is not a valid shift value, 1 is added to the value to determine the bit to set in the bitmask and, correspondingly, The TC dispatcher adds 1 to the return value from the BPF program before it compares it to the configured bit mask.

I also tweaked the display for `bpfctl list` a little.