### PR TITLE
Bump tonic to 0.9.2 and rustls to 0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ dependencies = [
  "nix",
  "oci-distribution",
  "openssl",
+ "rustls 0.21.1",
  "serde",
  "serde_json",
  "sha2",
@@ -1036,9 +1037,9 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -1845,13 +1846,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "tower-service",
  "trust-dns-resolver",
@@ -1916,12 +1917,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2304,9 +2327,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.1",
+ "tokio",
 ]
 
 [[package]]
@@ -2371,14 +2404,14 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2390,24 +2423,21 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2478,16 +2508,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/bpfctl/Cargo.toml
+++ b/bpfctl/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/bpfd-dev/bpfd"
 
 [dependencies]
 bpfd-api = { version = "0.1.0", path = "../bpfd-api" }
-tonic = { version = "0.8.0", features = ["tls"] }
+tonic = { version = "0.9.2", features = ["tls"] }
 prost = "0.11"
 anyhow = "1"
 clap = { version = "4", features = ["derive"]}

--- a/bpfd-api/Cargo.toml
+++ b/bpfd-api/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bpfd-dev/bpfd"
 
 [dependencies]
 anyhow = "1"
-tonic = { version = "0.8.0", features = ["tls"] }
+tonic = { version = "0.9.2", features = ["tls"] }
 prost = "0.11"
 thiserror = "1"
 tokio = { version = "1.27.0", features = ["full"] }

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -22,7 +22,8 @@ uuid = { version = "1", features = ["v4"] }
 log = "0.4"
 env_logger = "0.10"
 systemd-journal-logger = "1.0.0"
-tonic = "0.8.0"
+tonic = "0.9.2"
+rustls = "0.21.1"
 bpfd-api = { version = "0.1.0", path = "../bpfd-api" }
 caps = "0.5.4"
 nix = { version = "0.26", features = [ "socket", "fs", "mount"]}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Many of these values are defaults taken from:
+# https://docs.codecov.com/docs/commit-status
+coverage:
+  status:
+    patch:
+      default:
+        # TODO(astoycos) set this back to auto when we have a stable release.
+        target: 0%
+        threshold: 0%
+    project:
+      default:
+        # base
+        target: auto
+        # TODO(astoycos) set this back to 0% when we have a stable release.
+        threshold: 10%

--- a/scripts/certificates.sh
+++ b/scripts/certificates.sh
@@ -32,10 +32,7 @@ cert_init() {
     fi
 
     cert_client "${BIN_BPFD}" "${USER_BPFD}" ${regen}
-    cert_client "${BIN_BPFCTL}" "${USER_BPFD}" ${regen}
-    if [ "${regen}" == true ]; then
-        cert_client "${BIN_GOCOUNTER}" "${USER_BPFD}" ${regen}
-    fi
+    cert_client "${BIN_BPFD_CLIENT}" "${USER_BPFD}" ${regen}
 }
 
 cert_client() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,7 +14,7 @@ USER_BPFD="bpfd"
 USER_GROUP="bpfd"
 BIN_BPFD="bpfd"
 BIN_BPFCTL="bpfctl"
-BIN_GOCOUNTER="gocounter"
+BIN_BPFD_CLIENT="bpfd-client"
 
 # Well known directories
 SRC_BIN_PATH="../target/debug"
@@ -56,6 +56,8 @@ usage() {
     echo "    the \"bpfd\" service if it is running."
     echo "sudo ./scripts/setup.sh kubectl"
     echo "    Install kubectl plugins for \"bpfprogramconfigs\" and \"bpfprograms\"."
+    echo "sudo ./scripts/setup.sh certs"
+    echo "    Debug only. Generate OpenSSL based certificates instead of rustls based certificates."
     echo ""
 }
 
@@ -82,6 +84,9 @@ case "$1" in
         ;;
     "kubectl")
         copy_kubectl_plugin
+        ;;
+    "certs")
+        cert_init true
         ;;
     "help"|"--help"|"?")
         usage

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,5 +9,5 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 lazy_static = "1"
 serde_json = "1"
-tonic-build = "0.8.0"
-tonic = "0.8.0"
+tonic-build = "0.9.2"
+tonic = "0.9.2"


### PR DESCRIPTION
The tonic bump to 0.9.2 brought in rustls 0.20.0. With this bump, as well as the bump of OpenSSL to 0.10.52, mTLS between client and server were broken.

There was a bug in rustls (see https://github.com/rustls/rustls/issues/1288) where the certificate created by the rust server could not be parsed by the GO client (but an identical OpenSSL based certificate could be parsed). This was fixed in rustls 0.21.1.

rust-openssl was also updated in this timeframe, which cause an error parsing the rust generated certificate in the rust client (bpfctl). See https://github.com/rustls/rustls/issues/1292. This is fixed by this PR by changing how the certicate was created. The `.dns()` line below was causing the problem. A partial fix was implemented in #448, which fixed the GO clients, but the rust clients were still broken.
```
    let subject_alt_name = SubjectAlternativeName::new()
        .dns("localhost, IP:127.0.0.1")
        .build(&cert_builder.x509v3_context(Some(&ca_cert_x590), None))?;
```
As part of this fix, fixed up the `scripts/certificate.sh` file to generate the certificates properly using OpenSSL. This helped a lot in debugging this issue. Also rearranged the `bpfd/src/cert.rs` file to match the certificate created in the script so they lined up side-by-side.

Resolves: #398
Resolves: #411
Resolves: #424
Resolves: #451