### PR TITLE
Improve endpoint configuration

### DIFF
--- a/bpfd-api/src/config.rs
+++ b/bpfd-api/src/config.rs
@@ -146,8 +146,9 @@ pub enum Endpoint {
 
 impl Default for Endpoint {
     fn default() -> Self {
-        Endpoint::Unix {
-            path: default_unix(),
+        Endpoint::Tcp {
+            address: default_address(),
+            port: default_port(),
             enabled: default_enabled(),
         }
     }
@@ -285,8 +286,13 @@ mod test {
         assert_eq!(endpoints.len(), 1);
 
         match endpoints.get(0).unwrap() {
-            Endpoint::Unix { path, enabled } => {
-                assert_eq!(path, &default_unix());
+            Endpoint::Tcp {
+                address,
+                port,
+                enabled,
+            } => {
+                assert_eq!(address, &default_address());
+                assert_eq!(port, &default_port());
                 assert_eq!(enabled, &true);
             }
             _ => panic!("Failed to parse empty configuration"),

--- a/bpfd-operator/cmd/bpfd-agent/main.go
+++ b/bpfd-operator/cmd/bpfd-agent/main.go
@@ -40,10 +40,8 @@ import (
 	"github.com/bpfd-dev/bpfd/bpfd-operator/internal/tls"
 	gobpfd "github.com/bpfd-dev/bpfd/clients/gobpfd/v1"
 	v1 "k8s.io/api/core/v1"
-
 	//+kubebuilder:scaffold:imports
-
-	"google.golang.org/grpc"
+	//"google.golang.org/grpc"
 	//"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -110,9 +108,8 @@ func main() {
 	}
 
 	// Set up a connection to bpfd, block until bpfd is up.
-	addr := fmt.Sprintf("localhost:%d", configFileData.Grpc.Endpoint.Port)
-	setupLog.WithValues("addr", addr).WithValues("creds", creds).Info("Waiting for active connection to bpfd at %s")
-	conn, err := grpc.DialContext(context.Background(), addr, grpc.WithTransportCredentials(creds), grpc.WithBlock())
+	setupLog.WithValues("endpoints", configFileData.Grpc.Endpoints).WithValues("creds", creds).Info("Waiting for active connection to bpfd")
+	conn, err := tls.CreateConnection(configFileData.Grpc.Endpoints, context.Background(), creds)
 	if err != nil {
 		setupLog.Error(err, "unable to connect to bpfd")
 		os.Exit(1)

--- a/bpfd-operator/internal/constants.go
+++ b/bpfd-operator/internal/constants.go
@@ -34,7 +34,10 @@ const (
 	DefaultKeyPath                       = "/etc/bpfd/certs/bpfd/tls.key"
 	DefaultClientCertPath                = "/etc/bpfd/certs/bpfd-client/tls.crt"
 	DefaultClientKeyPath                 = "/etc/bpfd/certs/bpfd-client/tls.key"
+	DefaultType                          = "tcp"
+	DefaultPath                          = "/run/bpfd/bpfd.sock"
 	DefaultPort                          = 50051
+	DefaultEnabled                       = true
 )
 
 // Must match the internal bpfd-api mappings

--- a/bpfd/src/bpf.rs
+++ b/bpfd/src/bpf.rs
@@ -585,8 +585,8 @@ impl BpfManager {
                     }
                 }
             }
-            info!("Stopping processing commands");
         }
+        info!("Stopping processing commands");
     }
 
     async fn load_xdp_command(&mut self, args: LoadXDPArgs) -> anyhow::Result<()> {

--- a/bpfd/src/serve.rs
+++ b/bpfd/src/serve.rs
@@ -4,14 +4,18 @@
 use std::{fs::remove_file, net::SocketAddr, path::Path};
 
 use anyhow::Context;
-use bpfd_api::{config::Config, v1::loader_server::LoaderServer};
-use log::{debug, error, info};
+use bpfd_api::{
+    config::{self, Config},
+    v1::loader_server::LoaderServer,
+};
+use log::{debug, info};
 use tokio::{
     join,
     net::UnixListener,
     select,
     signal::unix::{signal, SignalKind},
     sync::mpsc,
+    task::JoinHandle,
 };
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::transport::{Server, ServerTlsConfig};
@@ -26,41 +30,10 @@ const SOCK_MODE: u32 = 0o0770;
 
 pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<()> {
     let (tx, rx) = mpsc::channel(32);
-    let endpoint = &config.grpc.endpoint;
 
     let loader = BpfdLoader::new(tx.clone());
     let service = LoaderServer::new(loader);
 
-    let unix = endpoint.unix.clone();
-    if Path::new(&unix).exists() {
-        // Attempt to remove the socket, since bind fails if it exists
-        remove_file(&unix)?;
-    }
-
-    let uds = UnixListener::bind(&unix)?;
-    let uds_stream = UnixListenerStream::new(uds);
-    set_file_permissions(&unix, SOCK_MODE).await;
-
-    let serve = Server::builder()
-        .add_service(service.clone())
-        .serve_with_incoming_shutdown(uds_stream, shutdown_handler());
-
-    let unix_listener = async move {
-        info!("Listening on {}", unix);
-        if let Err(e) = serve.await {
-            error!("unix socket error: {e:?}");
-        }
-        info!("Shutdown Unix Handler {}", unix);
-    };
-
-    let ip = endpoint.address.parse().map_err(|_| {
-        BpfdError::Error(format!(
-            "failed to parse listening address '{}'",
-            endpoint.address
-        ))
-    })?;
-    let port = endpoint.port;
-    let addr = SocketAddr::new(ip, port);
     let (ca_cert, identity) = get_tls_config(&config.tls)
         .await
         .context("CA Cert File does not exist")?;
@@ -69,18 +42,38 @@ pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<
         .identity(identity)
         .client_ca_root(ca_cert);
 
-    let serve = Server::builder()
-        .tls_config(tls_config)?
-        .add_service(service.clone())
-        .serve_with_shutdown(addr, shutdown_handler());
+    let mut listeners: Vec<_> = Vec::new();
 
-    let tcp_listener = async move {
-        info!("Listening on {addr}");
-        if let Err(e) = serve.await {
-            error!("tcp error: {e:?}");
+    for endpoint in &config.grpc.endpoints {
+        match endpoint {
+            config::Endpoint::Tcp {
+                address,
+                port,
+                enabled,
+            } => {
+                if !enabled {
+                    info!("Skipping disabled endpoint on {address}, port: {port}");
+                    continue;
+                }
+
+                match serve_tcp(address, *port, tls_config.clone(), service.clone()).await {
+                    Ok(handle) => listeners.push(handle),
+                    Err(e) => eprintln!("Error = {e:?}"),
+                }
+            }
+            config::Endpoint::Unix { path, enabled } => {
+                if !enabled {
+                    info!("Skipping disabled endpoint on {path}");
+                    continue;
+                }
+
+                match serve_unix(path.clone(), service.clone()).await {
+                    Ok(handle) => listeners.push(handle),
+                    Err(e) => eprintln!("Error = {e:?}"),
+                }
+            }
         }
-        info!("Shutdown TCP Handler {}", addr);
-    };
+    }
 
     let mut bpf_manager = BpfManager::new(config, rx);
     bpf_manager.rebuild_state().await?;
@@ -94,7 +87,7 @@ pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<
             info!("Loaded static program with UUID {}", uuid)
         }
     };
-    join!(unix_listener, tcp_listener, bpf_manager.process_commands());
+    join!(join_listeners(listeners), bpf_manager.process_commands());
     Ok(())
 }
 
@@ -105,4 +98,65 @@ pub(crate) async fn shutdown_handler() {
         _ = sigint.recv() => {debug!("Received SIGINT")},
         _ = sigterm.recv() => {debug!("Received SIGTERM")},
     }
+}
+
+async fn join_listeners(listeners: Vec<JoinHandle<()>>) {
+    for listener in listeners {
+        match listener.await {
+            Ok(()) => {}
+            Err(e) => eprintln!("Error = {e:?}"),
+        }
+    }
+}
+
+async fn serve_unix(
+    path: String,
+    service: LoaderServer<BpfdLoader>,
+) -> anyhow::Result<JoinHandle<()>> {
+    // Listen on Unix socket
+    if Path::new(&path).exists() {
+        // Attempt to remove the socket, since bind fails if it exists
+        remove_file(&path)?;
+    }
+
+    let uds = UnixListener::bind(&path)?;
+    let uds_stream = UnixListenerStream::new(uds);
+    set_file_permissions(&path, SOCK_MODE).await;
+
+    let serve = Server::builder()
+        .add_service(service)
+        .serve_with_incoming_shutdown(uds_stream, shutdown_handler());
+
+    Ok(tokio::spawn(async move {
+        info!("Listening on {path}");
+        if let Err(e) = serve.await {
+            eprintln!("Error = {e:?}");
+        }
+        info!("Shutdown Unix Handler {}", path);
+    }))
+}
+
+async fn serve_tcp(
+    address: &String,
+    port: u16,
+    tls_config: ServerTlsConfig,
+    service: LoaderServer<BpfdLoader>,
+) -> anyhow::Result<JoinHandle<()>> {
+    let ip = address
+        .parse()
+        .map_err(|_| BpfdError::Error(format!("failed to parse listening address'{}'", address)))?;
+    let addr = SocketAddr::new(ip, port);
+
+    let serve = Server::builder()
+        .tls_config(tls_config)?
+        .add_service(service)
+        .serve_with_shutdown(addr, shutdown_handler());
+
+    Ok(tokio::spawn(async move {
+        info!("Listening on {addr}");
+        if let Err(e) = serve.await {
+            eprintln!("Error = {e:?}");
+        }
+        info!("Shutdown TCP Handler {}", addr);
+    }))
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,8 @@ There is an example at `scripts/bpfd.toml`, similar to:
   [interface.eth0]
   xdp_mode = "hw" # Valid xdp modes are "hw", "skb" and "drv". Default: "skb".
 
-[grpc.endpoint]
+[[grpc.endpoints]]
+  type = "tcp"
   address = "::1"
   port = 50051
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,12 +21,69 @@ There is an example at `scripts/bpfd.toml`, similar to:
 
 [[grpc.endpoints]]
   type = "tcp"
+  enabled = true
   address = "::1"
   port = 50051
+
+[[grpc.endpoints]]
+  type = "unix"
+  enabled = false
+  path = "/run/bpfd/bpfd.sock"
 ```
 
 `bpfctl` and `bpfd-agent` (which is only used in Kubernetes type deployments) will also read the
 bpfd configuration file (`/etc/bpfd/bpfd.toml`) to retrieve the bpfd-client certificate file locations.
+
+#### Config Section: [tls]
+
+This section of the configuration file allows the mTLS certificate authority file locations to be overwritten.
+If the given certificates exist, then bpfd will use them.
+Otherwise, bpfd will create them.
+Default values are shown above.
+
+Valid fields:
+- ca_cert: Certificate authority file location, intended to be used by bpfd and client.
+- cert: Certificate file location, intended to be used by bpfd.
+- key: Certificate key location, intended to be used by bpfd.
+- client_cert: Client certificate file location, intended to be used by bpfd clients (`bpfctl`, `bpfd-agent`, etc).
+- client_key: Client certificate key file location, intended to be used by bpfd clients (`bpfctl`, `bpfd-agent`, etc).
+
+If bpfd is running as a systemd service, then the certificates must be accessible by bpfd
+(owned by the bpfd User and User Group).
+
+#### Config Section: [interfaces]
+
+This section of the configuration file allows the XDP Mode for a given interface to be set.
+If not set, the default value of skb will be used.
+Multiple interfaces can be configured.
+
+```toml
+[interfaces]
+  [interfaces.eth0]
+  xdp_mode = "drv"
+  [interfaces.eth1]
+  xdp_mode = "hw"
+  [interfaces.eth2]
+  xdp_mode = "skb"
+```
+
+Valid fields:
+- xdp_mode: XDP Mode for a given interface. Valid values: ["drv"|"hw"|"skb"]
+
+#### Config Section: [grpc.endpoints]
+
+In this section different endpoints can be configured for bpfd to listen on. We currently support TCP sockets
+with IPv4 and Ipv6 addresses and Unix domain sockets.
+When using TCP sockets, the tls configuration will be used to secure communication.
+Unix domain sockets provide a simpler communication with no encryption. These sockets are owned by the bpfd
+user and user group when running as a systemd or non-root process.
+
+Valid fields:
+- type: Specify if the endpoint will listen on a TCP or Unix domain socket. Valid values: ["tcp"|"unix"]
+- enabled: Configure whether bpfd should listen on the endpoint. Valid values: ["true"|"false"]
+- address: Exclusive to TCP sockets. Specify the address the endpoint should listen on. Valid values: Any valid IPv4 or IPv6 address.
+- port: Exclusive to TCP sockets. Specify the port bpfd should listen on. Valid values: An integer between 1024 and 65535.
+- path: Exclusive to Unix sockets. Specify the path where the socket will be created. Valid values: A valid unix path.
 
 ### Loading Programs at system launch time
 

--- a/examples/go-tc-counter/main.go
+++ b/examples/go-tc-counter/main.go
@@ -16,7 +16,6 @@ import (
 	gobpfd "github.com/bpfd-dev/bpfd/clients/gobpfd/v1"
 	configMgmt "github.com/bpfd-dev/bpfd/examples/pkg/config-mgmt"
 	"github.com/cilium/ebpf"
-	"google.golang.org/grpc"
 )
 
 type Stats struct {
@@ -85,10 +84,9 @@ func main() {
 			}
 
 			// Set up a connection to the server.
-			addr := fmt.Sprintf("localhost:%d", configFileData.Grpc.Endpoint.Port)
-			conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(creds))
+			conn, err := configMgmt.CreateConnection(configFileData.Grpc.Endpoints, ctx, creds)
 			if err != nil {
-				log.Printf("did not connect: %v", err)
+				log.Printf("failed to create client connection: %v", err)
 				return
 			}
 			c := gobpfd.NewLoaderClient(conn)

--- a/examples/go-xdp-counter/main.go
+++ b/examples/go-xdp-counter/main.go
@@ -16,7 +16,6 @@ import (
 	gobpfd "github.com/bpfd-dev/bpfd/clients/gobpfd/v1"
 	configMgmt "github.com/bpfd-dev/bpfd/examples/pkg/config-mgmt"
 	"github.com/cilium/ebpf"
-	"google.golang.org/grpc"
 )
 
 type Stats struct {
@@ -77,13 +76,12 @@ func main() {
 				return
 			}
 
-			// Set up a connection to the server.
-			addr := fmt.Sprintf("localhost:%d", configFileData.Grpc.Endpoint.Port)
-			conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(creds))
+			conn, err := configMgmt.CreateConnection(configFileData.Grpc.Endpoints, ctx, creds)
 			if err != nil {
-				log.Printf("did not connect: %v", err)
+				log.Printf("failed to create client connection: %v", err)
 				return
 			}
+
 			c := gobpfd.NewLoaderClient(conn)
 			loadRequestCommon := &gobpfd.LoadRequestCommon{
 				Location:    paramData.BytecodeSource.Location,

--- a/examples/pkg/config-mgmt/configfile.go
+++ b/examples/pkg/config-mgmt/configfile.go
@@ -17,6 +17,7 @@ limitations under the License.
 package configMgmt
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -24,7 +25,9 @@ import (
 	"os"
 
 	toml "github.com/pelletier/go-toml"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 type Tls struct {
@@ -36,11 +39,14 @@ type Tls struct {
 }
 
 type Endpoint struct {
-	Port uint16 `toml:"port"`
+	Type    string `toml:"type"`
+	Path    string `toml:"path"`
+	Port    uint16 `toml:"port"`
+	Enabled bool   `toml:"enabled"`
 }
 
 type Grpc struct {
-	Endpoint Endpoint `toml:"endpoint"`
+	Endpoints []Endpoint `toml:"endpoints"`
 }
 
 type ConfigFileData struct {
@@ -54,7 +60,9 @@ const (
 	DefaultKeyPath        = "/etc/bpfd/certs/bpfd/tls.key"
 	DefaultClientCertPath = "/etc/bpfd/certs/bpfd-client/bpfd-client.pem"
 	DefaultClientKeyPath  = "/etc/bpfd/certs/bpfd-client/bpfd-client.key"
+	DefaultType           = "tcp"
 	DefaultPort           = 50051
+	DefaultEnabled        = true
 )
 
 func LoadConfig(configFilePath string) ConfigFileData {
@@ -67,8 +75,12 @@ func LoadConfig(configFilePath string) ConfigFileData {
 			ClientKey:  DefaultClientKeyPath,
 		},
 		Grpc: Grpc{
-			Endpoint: Endpoint{
-				Port: DefaultPort,
+			Endpoints: []Endpoint{
+				{
+					Type:    DefaultType,
+					Port:    DefaultPort,
+					Enabled: DefaultEnabled,
+				},
 			},
 		},
 	}
@@ -112,4 +124,33 @@ func LoadTLSCredentials(tlsFiles Tls) (credentials.TransportCredentials, error) 
 	}
 
 	return credentials.NewTLS(config), nil
+}
+
+func CreateConnection(endpoints []Endpoint, ctx context.Context, creds credentials.TransportCredentials) (*grpc.ClientConn, error) {
+	var (
+		addr        string
+		local_creds credentials.TransportCredentials
+	)
+
+	for _, e := range endpoints {
+		if !e.Enabled {
+			continue
+		}
+
+		if e.Type == "tcp" {
+			addr = fmt.Sprintf("localhost:%d", e.Port)
+			local_creds = creds
+		} else if e.Type == "unix" {
+			addr = fmt.Sprintf("unix://%s", e.Path)
+			local_creds = insecure.NewCredentials()
+		}
+
+		conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(local_creds))
+		if err == nil {
+			return conn, nil
+		}
+		log.Printf("did not connect: %v", err)
+	}
+
+	return nil, fmt.Errorf("unable to stablish connection")
 }

--- a/scripts/bpfd.toml
+++ b/scripts/bpfd.toml
@@ -9,6 +9,7 @@
   [interface.eth0]
   xdp_mode = "hw" # Valid xdp modes are "hw", "skb" and "drv". Default: "skb".
 
-[grpc.endpoint]
+[[grpc.endpoints]]
+  type = "tcp"
   address = "::1"
   port = 50051

--- a/scripts/bpfd.toml
+++ b/scripts/bpfd.toml
@@ -11,5 +11,11 @@
 
 [[grpc.endpoints]]
   type = "tcp"
+  enabled = true
   address = "::1"
   port = 50051
+
+[[grpc.endpoints]]
+  type = "unix"
+  enabled = false
+  path = "/run/bpfd/bpfd.sock"


### PR DESCRIPTION
Endpoint configuration now allows multiple unix and TCP sockets to be used for use as both server in bpfd and client in bpfctl. Individual endpoints can also be enabled and disabled via configuration. For client connections, priority is determined by the order the endpoints are listed in the TOML configuration file.

Fixes #418 

TODO:
- [x] Change go examples to use the new configuration.
- [x] Revisit config unit tests.
- [x] Change existing documentation.
- [x] Change existing bpfd.toml.