### PR TITLE
Remove Ok from TCProceedOn defaults

### DIFF
--- a/bpfd-api/src/lib.rs
+++ b/bpfd-api/src/lib.rs
@@ -402,7 +402,6 @@ pub struct TcProceedOn(pub(crate) Vec<TcProceedOnEntry>);
 impl Default for TcProceedOn {
     fn default() -> Self {
         TcProceedOn(vec![
-            TcProceedOnEntry::Ok,
             TcProceedOnEntry::Pipe,
             TcProceedOnEntry::DispatcherReturn,
         ])

--- a/bpfd-operator/apis/v1alpha1/tcProgram_types.go
+++ b/bpfd-operator/apis/v1alpha1/tcProgram_types.go
@@ -66,7 +66,7 @@ type TcProgramSpec struct {
 	// Multiple values are supported by repeating the parameter.
 	// +optional
 	// +kubebuilder:validation:MaxItems=11
-	// +kubebuilder:default:={ok,pipe,dispatcher_return}
+	// +kubebuilder:default:={pipe,dispatcher_return}
 	ProceedOn []TcProceedOnValue `json:"proceedon"`
 }
 

--- a/bpfd-operator/config/crd/bases/bpfd.io_tcprograms.yaml
+++ b/bpfd-operator/config/crd/bases/bpfd.io_tcprograms.yaml
@@ -175,7 +175,6 @@ spec:
                 type: integer
               proceedon:
                 default:
-                - ok
                 - pipe
                 - dispatcher_return
                 description: ProceedOn allows the user to call other tc programs in

--- a/bpfd-operator/controllers/bpfd-agent/tc-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program_test.go
@@ -76,9 +76,10 @@ func TestTcProgramControllerCreate(t *testing.T) {
 			},
 			Priority:  0,
 			Direction: direction,
-			ProceedOn: []bpfdiov1alpha1.TcProceedOnValue{bpfdiov1alpha1.TcProceedOnValue("ok"),
+			ProceedOn: []bpfdiov1alpha1.TcProceedOnValue{
 				bpfdiov1alpha1.TcProceedOnValue("pipe"),
-				bpfdiov1alpha1.TcProceedOnValue("dispatcher_return")},
+				bpfdiov1alpha1.TcProceedOnValue("dispatcher_return"),
+			},
 		},
 	}
 
@@ -164,7 +165,7 @@ func TestTcProgramControllerCreate(t *testing.T) {
 				Iface:     fakeInt,
 				Priority:  0,
 				Direction: direction,
-				ProceedOn: []int32{0, 3, 30},
+				ProceedOn: []int32{3, 30},
 			},
 		},
 	}

--- a/bpfd-operator/controllers/bpfd-operator/tc-program_test.go
+++ b/bpfd-operator/controllers/bpfd-operator/tc-program_test.go
@@ -68,9 +68,10 @@ func TestTcProgramReconcile(t *testing.T) {
 			},
 			Priority:  0,
 			Direction: direction,
-			ProceedOn: []bpfdiov1alpha1.TcProceedOnValue{bpfdiov1alpha1.TcProceedOnValue("ok"),
+			ProceedOn: []bpfdiov1alpha1.TcProceedOnValue{
 				bpfdiov1alpha1.TcProceedOnValue("pipe"),
-				bpfdiov1alpha1.TcProceedOnValue("dispatcher_return")},
+				bpfdiov1alpha1.TcProceedOnValue("dispatcher_return"),
+			},
 		},
 	}
 


### PR DESCRIPTION
This makes our default TC dispatcher behavior the same as standard TC:

`TC_ACT_OK`, will terminate the packet processing pipeline and allows the packet to proceed
`TC_ACT_PIPE`, will iterate to the next action, if available