### PR TITLE
Fix setting of global data in extension programs

### DIFF
--- a/bpfd/src/bpf.rs
+++ b/bpfd/src/bpf.rs
@@ -267,12 +267,6 @@ impl BpfManager {
                 .await
                 .map_err(|e| BpfdError::Error(format!("can't create map dir: {e}")))?;
 
-            let mut loader = BpfLoader::new();
-
-            for (name, value) in &program.data.global_data {
-                loader.set_global(name, value.as_slice());
-            }
-
             let program_bytes = if program
                 .data
                 .path
@@ -284,7 +278,13 @@ impl BpfManager {
                 read(program.data.path.clone()).await?
             };
 
-            let mut loader = BpfLoader::new()
+            let mut loader = BpfLoader::new();
+
+            for (name, value) in &program.data.global_data {
+                loader.set_global(name, value.as_slice());
+            }
+
+            let mut loader = loader
                 .map_pin_path(map_pin_path.clone())
                 .load(&program_bytes)?;
 

--- a/bpfd/src/multiprog/tc.rs
+++ b/bpfd/src/multiprog/tc.rs
@@ -193,12 +193,6 @@ impl TcDispatcher {
                 let path = format!("{base}/dispatcher_{if_index}_{}/link_{k}", self.revision);
                 new_link.pin(path).map_err(BpfdError::UnableToPinLink)?;
             } else {
-                let mut bpf = BpfLoader::new();
-
-                for (name, value) in &v.data.global_data {
-                    bpf.set_global(name, value.as_slice());
-                }
-
                 let program_bytes = if v.data.path.clone().contains(BYTECODE_IMAGE_CONTENT_STORE) {
                     get_bytecode_from_image_store(v.data.path.clone()).await?
                 } else {
@@ -207,7 +201,13 @@ impl TcDispatcher {
                     })?
                 };
 
-                let mut bpf = BpfLoader::new()
+                let mut bpf = BpfLoader::new();
+
+                for (name, value) in &v.data.global_data {
+                    bpf.set_global(name, value.as_slice());
+                }
+
+                let mut bpf = bpf
                     .map_pin_path(format!("{RTDIR_FS_MAPS}/{k}"))
                     .extension(&v.data.section_name)
                     .load(&program_bytes)

--- a/bpfd/src/multiprog/xdp.rs
+++ b/bpfd/src/multiprog/xdp.rs
@@ -174,12 +174,6 @@ impl XdpDispatcher {
                 );
                 new_link.pin(path).map_err(BpfdError::UnableToPinLink)?;
             } else {
-                let mut bpf = BpfLoader::new();
-
-                for (name, value) in &v.data.global_data {
-                    bpf.set_global(name, value.as_slice());
-                }
-
                 let program_bytes = if v.data.path.clone().contains(BYTECODE_IMAGE_CONTENT_STORE) {
                     get_bytecode_from_image_store(v.data.path.clone()).await?
                 } else {
@@ -188,7 +182,13 @@ impl XdpDispatcher {
                     })?
                 };
 
-                let mut bpf = BpfLoader::new()
+                let mut bpf = BpfLoader::new();
+
+                for (name, value) in &v.data.global_data {
+                    bpf.set_global(name, value.as_slice());
+                }
+
+                let mut bpf = bpf
                     .map_pin_path(format!("{RTDIR_FS_MAPS}/{k}"))
                     .extension(&v.data.section_name)
                     .load(&program_bytes)


### PR DESCRIPTION
With changes in pr #372, the BpfLoader was getting re-initialized after the global values were set.

Fixes: #500