### PR TITLE
Cut 0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "bpfctl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "bpfd"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "aya",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "bpfd-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "aya",

--- a/bpfctl/Cargo.toml
+++ b/bpfctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpfctl"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A client for working with bpfd"
 license = "MIT OR Apache-2.0"
@@ -11,7 +11,7 @@ repository = "https://github.com/bpfd-dev/bpfd"
     path = "src/main.rs"
 
 [dependencies]
-bpfd-api = { version = "0.1.0", path = "../bpfd-api" }
+bpfd-api = { version = "0.2.0", path = "../bpfd-api" }
 tonic = { version = "0.9.2", features = ["tls"] }
 prost = "0.11"
 anyhow = "1"

--- a/bpfd-api/Cargo.toml
+++ b/bpfd-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpfd-api"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "gRPC bindings to the bpfd API"
 license = "MIT OR Apache-2.0"

--- a/bpfd-operator/Makefile
+++ b/bpfd-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.0
+VERSION ?= 0.2.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bpfd-operator/bundle/manifests/bpfd-operator.clusterserviceversion.yaml
+++ b/bpfd-operator/bundle/manifests/bpfd-operator.clusterserviceversion.yaml
@@ -74,11 +74,11 @@ metadata:
       ]
     capabilities: Basic Install
     containerImage: quay.io/bpfd/bpfd-operator:v0.0.0
-    createdAt: "2023-05-16T18:59:47Z"
+    createdAt: "2023-05-18T20:19:38Z"
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/bpfd-dev/bpfd
-  name: bpfd-operator.v0.0.0
+  name: bpfd-operator.v0.2.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -428,4 +428,4 @@ spec:
   provider:
     name: The bpfd Community
     url: https://bpfd.netlify.app/
-  version: 0.0.0
+  version: 0.2.0

--- a/bpfd-operator/hack/boilerplate.sh.txt
+++ b/bpfd-operator/hack/boilerplate.sh.txt
@@ -1,15 +1,13 @@
-/*
-Copyright YEAR The bpfd Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bpfd"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A system daemon for loading BPF programs"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ env_logger = "0.10"
 systemd-journal-logger = "1.0.0"
 tonic = "0.9.2"
 rustls = "0.21.1"
-bpfd-api = { version = "0.1.0", path = "../bpfd-api" }
+bpfd-api = { version = "0.2.0", path = "../bpfd-api" }
 caps = "0.5.4"
 nix = { version = "0.26", features = [ "socket", "fs", "mount"]}
 serde = { version = "1.0", features = ["derive"] }

--- a/changelogs/CHANGELOG-v0.2.0.md
+++ b/changelogs/CHANGELOG-v0.2.0.md
@@ -1,0 +1,14 @@
+The v0.2.0 release is our first official minor release of the bpfd project.
+
+Major new enhancements include:
+
+- Support for TC and Tracepoint programs
+- Kubernetes Operator and redesigned CRDs:
+  - `BpfProgram`
+  - `TcProgram`
+  - `XdpProgram`
+  - `TracepointProgram`
+- Improved documentation
+- e2e testing and expanded integration tests
+- Improved Examples
+- Many bug fixes


### PR DESCRIPTION
This adds the changelog for bpfd's 0.2.0 release.

Updates the bpfd-operator bundle version.

Updates the bpfd, bpfctl, and bpfd-api versions to 0.2.0.

Fixes a small bug in one of our boilerplates

Fixes #393 