### PR TITLE
Temp fix for Ubuntu-latest mirror issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
           if-no-files-found: error
 
   basic-integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: ["build", "build-go"]
     env:
       CARGO_TERM_COLOR: always


### PR DESCRIPTION
Try to temporally fix our CI by reverting the ubuntu base image.