### PR TITLE
chore: move condition types to public API

### DIFF
--- a/bpfd-operator/apis/v1alpha1/shared_types.go
+++ b/bpfd-operator/apis/v1alpha1/shared_types.go
@@ -102,3 +102,169 @@ type ImagePullSecretSelector struct {
 	// Namespace of the secret which contains the credentials to access the image repository.
 	Namespace string `json:"namespace"`
 }
+
+// -----------------------------------------------------------------------------
+// Status Conditions - BPF Programs
+// -----------------------------------------------------------------------------
+
+// ProgramConditionType is a condition type to indicate the status of a BPF
+// program at the cluster level.
+type ProgramConditionType string
+
+const (
+	// ProgramNotYetLoaded indicates that the program in question has not
+	// yet been loaded on all nodes in the cluster.
+	ProgramNotYetLoaded ProgramConditionType = "NotYetLoaded"
+
+	// ProgramReconcileError indicates that an unforseen situation has
+	// occurred in the controller logic, and the controller will retry.
+	ProgramReconcileError ProgramConditionType = "ReconcileError"
+
+	// BpfdProgConfigReconcileSuccess indicates that the BPF program has been
+	// successfully reconciled.
+	//
+	// TODO: we should consider removing "reconciled" type logic from the
+	// public API as it's an implementation detail of our use of controller
+	// runtime, but not necessarily relevant to human users or integrations.
+	//
+	// See: https://github.com/bpfd-dev/bpfd/issues/430
+	ProgramReconcileSuccess ProgramConditionType = "ReconcileSuccess"
+
+	// ProgramDeleteError indicates that the BPF program was marked for
+	// deletion, but deletion was unsuccessful.
+	ProgramDeleteError ProgramConditionType = "DeleteError"
+)
+
+// Condition is a helper method to promote any given ProgramConditionType to
+// a full metav1.Condition in an opinionated fashion.
+//
+// TODO: this was created in the early days to provide at least SOME status
+// information to the user, but the hardcoded messages need to be replaced
+// in the future with dynamic and situation-aware messages later.
+//
+// See: https://github.com/bpfd-dev/bpfd/issues/430
+func (b ProgramConditionType) Condition(message string) metav1.Condition {
+	cond := metav1.Condition{}
+
+	switch b {
+	case ProgramNotYetLoaded:
+		if len(message) == 0 {
+			message = "Waiting for Program Object to be reconciled to all nodes"
+		}
+
+		cond = metav1.Condition{
+			Type:    string(ProgramNotYetLoaded),
+			Status:  metav1.ConditionTrue,
+			Reason:  "ProgramsNotYetLoaded",
+			Message: message,
+		}
+	case ProgramReconcileError:
+		if len(message) == 0 {
+			message = "bpfProgramReconciliation failed"
+		}
+
+		cond = metav1.Condition{
+			Type:    string(ProgramReconcileError),
+			Status:  metav1.ConditionTrue,
+			Reason:  "ReconcileError",
+			Message: message,
+		}
+	case ProgramReconcileSuccess:
+		if len(message) == 0 {
+			message = "bpfProgramReconciliation Succeeded on all nodes"
+		}
+
+		cond = metav1.Condition{
+			Type:    string(ProgramReconcileSuccess),
+			Status:  metav1.ConditionTrue,
+			Reason:  "ReconcileSuccess",
+			Message: message,
+		}
+	case ProgramDeleteError:
+		if len(message) == 0 {
+			message = "Program Deletion failed"
+		}
+
+		cond = metav1.Condition{
+			Type:    string(ProgramDeleteError),
+			Status:  metav1.ConditionTrue,
+			Reason:  "DeleteError",
+			Message: message,
+		}
+	}
+
+	return cond
+}
+
+// BpfProgramConditionType is a condition type to indicate the status of a BPF
+// program at the individual node level.
+type BpfProgramConditionType string
+
+const (
+	// BpfProgCondLoaded indicates that the BPF program was successfully loaded
+	// into the kernel on a specific node.
+	BpfProgCondLoaded BpfProgramConditionType = "Loaded"
+
+	// BpfProgCondNotLoaded indicates that the BPF program has not yet been
+	// loaded into the kernel on a specific node.
+	BpfProgCondNotLoaded BpfProgramConditionType = "NotLoaded"
+
+	// BpfProgCondUnloaded indicates that in the midst of trying to remove a
+	// BPF program from the kernel on the node, that program has not yet been
+	// removed.
+	BpfProgCondNotUnloaded BpfProgramConditionType = "NotUnLoaded"
+
+	// BpfProgCondNotSelected indicates that the eBPF program is not scheduled to be loaded
+	// on a specific node.
+	BpfProgCondNotSelected BpfProgramConditionType = "NotSelected"
+
+	// BpfProgCondUnloaded indicates that a BPF program has been unloaded from
+	// the kernel on a specific node.
+	BpfProgCondUnloaded BpfProgramConditionType = "Unloaded"
+)
+
+// Condition is a helper method to promote any given BpfProgramConditionType to
+// a full metav1.Condition in an opinionated fashion.
+func (b BpfProgramConditionType) Condition() metav1.Condition {
+	cond := metav1.Condition{}
+
+	switch b {
+	case BpfProgCondLoaded:
+		cond = metav1.Condition{
+			Type:    string(BpfProgCondLoaded),
+			Status:  metav1.ConditionTrue,
+			Reason:  "bpfdLoaded",
+			Message: "Successfully loaded bpfProgram",
+		}
+	case BpfProgCondNotLoaded:
+		cond = metav1.Condition{
+			Type:    string(BpfProgCondNotLoaded),
+			Status:  metav1.ConditionTrue,
+			Reason:  "bpfdNotLoaded",
+			Message: "Failed to load bpfProgram",
+		}
+	case BpfProgCondNotUnloaded:
+		cond = metav1.Condition{
+			Type:    string(BpfProgCondNotUnloaded),
+			Status:  metav1.ConditionTrue,
+			Reason:  "bpfdNotUnloaded",
+			Message: "Failed to unload bpfProgram",
+		}
+	case BpfProgCondNotSelected:
+		cond = metav1.Condition{
+			Type:    string(BpfProgCondNotSelected),
+			Status:  metav1.ConditionTrue,
+			Reason:  "nodeNotSelected",
+			Message: "This node is not selected to run the bpfProgram",
+		}
+	case BpfProgCondUnloaded:
+		cond = metav1.Condition{
+			Type:    string(BpfProgCondUnloaded),
+			Status:  metav1.ConditionTrue,
+			Reason:  "bpfdUnloaded",
+			Message: "This BpfProgram object and all it's bpfd programs have been unloaded",
+		}
+	}
+
+	return cond
+}

--- a/bpfd-operator/controllers/bpfd-agent/tc-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program.go
@@ -167,11 +167,11 @@ func (r *TcProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 	existingBpfPrograms map[string]*gobpfd.ListResponse_ListResult,
 	bytecode interface{},
 	isNodeSelected bool,
-	isBeingDeleted bool) (bpfProgramConditionType, error) {
+	isBeingDeleted bool) (bpfdiov1alpha1.BpfProgramConditionType, error) {
 
 	ifaces, err := getInterfaces(&r.currentTcProgram.Spec.InterfaceSelector, r.ourNode)
 	if err != nil {
-		return BpfProgCondNotLoaded, fmt.Errorf("failed to get interfaces for TcProgram %s: %v", r.currentTcProgram.Name, err)
+		return bpfdiov1alpha1.BpfProgCondNotLoaded, fmt.Errorf("failed to get interfaces for TcProgram %s: %v", r.currentTcProgram.Name, err)
 	}
 
 	r.Logger.V(1).Info("Existing bpfProgramEntries", "ExistingEntries", r.bpfProgram.Spec.Programs)
@@ -215,7 +215,7 @@ func (r *TcProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 			bpfProgramEntry, err := bpfdagentinternal.LoadBpfdProgram(ctx, r.BpfdClient, loadRequest)
 			if err != nil {
 				r.Logger.Error(err, "Failed to load TcProgram")
-				return BpfProgCondNotLoaded, err
+				return bpfdiov1alpha1.BpfProgCondNotLoaded, err
 			}
 
 			bpfProgramEntries[id] = bpfProgramEntry
@@ -233,7 +233,7 @@ func (r *TcProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 				"isSelected", isNodeSelected)
 			if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, id); err != nil {
 				r.Logger.Error(err, "Failed to unload TcProgram")
-				return BpfProgCondLoaded, err
+				return bpfdiov1alpha1.BpfProgCondLoaded, err
 			}
 			delete(bpfProgramEntries, id)
 
@@ -247,13 +247,13 @@ func (r *TcProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 			r.Logger.V(1).Info("TcProgram is in wrong state, unloading and reloading")
 			if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, id); err != nil {
 				r.Logger.Error(err, "Failed to unload TcProgram")
-				return BpfProgCondNotUnloaded, err
+				return bpfdiov1alpha1.BpfProgCondNotUnloaded, err
 			}
 
 			bpfProgramEntry, err := bpfdagentinternal.LoadBpfdProgram(ctx, r.BpfdClient, loadRequest)
 			if err != nil {
 				r.Logger.Error(err, "Failed to load TcProgram")
-				return BpfProgCondNotLoaded, err
+				return bpfdiov1alpha1.BpfProgCondNotLoaded, err
 			}
 
 			r.Logger.V(1).WithValues("UUID", id, "ProgramEntry", bpfProgramEntry).Info("ReLoaded TcProgram on Node")
@@ -265,7 +265,7 @@ func (r *TcProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 				maps, err := bpfdagentinternal.GetMapsForUUID(id)
 				if err != nil {
 					r.Logger.Error(err, "failed to get bpfProgram's Maps")
-					return BpfProgCondNotLoaded, err
+					return bpfdiov1alpha1.BpfProgCondNotLoaded, err
 				}
 
 				bpfProgramEntries[id] = maps
@@ -281,12 +281,12 @@ func (r *TcProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 	r.expectedPrograms = bpfProgramEntries
 
 	if isBeingDeleted {
-		return BpfProgCondUnloaded, nil
+		return bpfdiov1alpha1.BpfProgCondUnloaded, nil
 	}
 
 	if !isNodeSelected {
-		return BpfProgCondNotSelected, nil
+		return bpfdiov1alpha1.BpfProgCondNotSelected, nil
 	}
 
-	return BpfProgCondLoaded, nil
+	return bpfdiov1alpha1.BpfProgCondLoaded, nil
 }

--- a/bpfd-operator/controllers/bpfd-agent/tc-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program_test.go
@@ -194,5 +194,5 @@ func TestTcProgramControllerCreate(t *testing.T) {
 	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
 	require.NoError(t, err)
 
-	require.Equal(t, string(BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)
+	require.Equal(t, string(bpfdiov1alpha1.BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)
 }

--- a/bpfd-operator/controllers/bpfd-agent/tracepoint-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/tracepoint-program_test.go
@@ -181,5 +181,5 @@ func TestTracepointProgramControllerCreate(t *testing.T) {
 	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
 	require.NoError(t, err)
 
-	require.Equal(t, string(BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)
+	require.Equal(t, string(bpfdiov1alpha1.BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)
 }

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program.go
@@ -157,11 +157,11 @@ func (r *XdpProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 	existingBpfPrograms map[string]*gobpfd.ListResponse_ListResult,
 	bytecode interface{},
 	isNodeSelected bool,
-	isBeingDeleted bool) (bpfProgramConditionType, error) {
+	isBeingDeleted bool) (bpfdiov1alpha1.BpfProgramConditionType, error) {
 
 	ifaces, err := getInterfaces(&r.currentXdpProgram.Spec.InterfaceSelector, r.ourNode)
 	if err != nil {
-		return BpfProgCondNotLoaded, fmt.Errorf("failed to get interfaces for XdpProgram %s: %v", r.currentXdpProgram.Name, err)
+		return bpfdiov1alpha1.BpfProgCondNotLoaded, fmt.Errorf("failed to get interfaces for XdpProgram %s: %v", r.currentXdpProgram.Name, err)
 	}
 
 	r.Logger.V(1).Info("Existing bpfProgramEntries", "ExistingEntries", r.bpfProgram.Spec.Programs)
@@ -204,7 +204,7 @@ func (r *XdpProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 			bpfProgramEntry, err := bpfdagentinternal.LoadBpfdProgram(ctx, r.BpfdClient, loadRequest)
 			if err != nil {
 				r.Logger.Error(err, "Failed to load XdpProgram")
-				return BpfProgCondNotLoaded, err
+				return bpfdiov1alpha1.BpfProgCondNotLoaded, err
 			}
 
 			bpfProgramEntries[id] = bpfProgramEntry
@@ -221,7 +221,7 @@ func (r *XdpProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 				"isSelected", isNodeSelected)
 			if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, id); err != nil {
 				r.Logger.Error(err, "Failed to unload XdpProgram")
-				return BpfProgCondLoaded, err
+				return bpfdiov1alpha1.BpfProgCondLoaded, err
 			}
 			delete(bpfProgramEntries, id)
 
@@ -235,13 +235,13 @@ func (r *XdpProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 			r.Logger.V(1).Info("XdpProgram is in wrong state, unloading and reloading")
 			if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, id); err != nil {
 				r.Logger.Error(err, "Failed to unload XdpProgram")
-				return BpfProgCondNotUnloaded, err
+				return bpfdiov1alpha1.BpfProgCondNotUnloaded, err
 			}
 
 			bpfProgramEntry, err := bpfdagentinternal.LoadBpfdProgram(ctx, r.BpfdClient, loadRequest)
 			if err != nil {
 				r.Logger.Error(err, "Failed to load XdpProgram")
-				return BpfProgCondNotLoaded, err
+				return bpfdiov1alpha1.BpfProgCondNotLoaded, err
 			}
 
 			r.Logger.V(1).WithValues("UUID", id, "ProgramEntry", bpfProgramEntry).Info("ReLoaded XdpProgram on Node")
@@ -253,7 +253,7 @@ func (r *XdpProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 				maps, err := bpfdagentinternal.GetMapsForUUID(id)
 				if err != nil {
 					r.Logger.Error(err, "failed to get bpfProgram's Maps")
-					return BpfProgCondNotLoaded, err
+					return bpfdiov1alpha1.BpfProgCondNotLoaded, err
 				}
 
 				bpfProgramEntries[id] = maps
@@ -268,12 +268,12 @@ func (r *XdpProgramReconciler) reconcileBpfdPrograms(ctx context.Context,
 	r.expectedPrograms = bpfProgramEntries
 
 	if isBeingDeleted {
-		return BpfProgCondUnloaded, nil
+		return bpfdiov1alpha1.BpfProgCondUnloaded, nil
 	}
 
 	if !isNodeSelected {
-		return BpfProgCondNotSelected, nil
+		return bpfdiov1alpha1.BpfProgCondNotSelected, nil
 	}
 
-	return BpfProgCondLoaded, nil
+	return bpfdiov1alpha1.BpfProgCondLoaded, nil
 }

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program_test.go
@@ -189,5 +189,5 @@ func TestXdpProgramControllerCreate(t *testing.T) {
 	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
 	require.NoError(t, err)
 
-	require.Equal(t, string(BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)
+	require.Equal(t, string(bpfdiov1alpha1.BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)
 }

--- a/bpfd-operator/controllers/bpfd-operator/configmap.go
+++ b/bpfd-operator/controllers/bpfd-operator/configmap.go
@@ -108,7 +108,7 @@ func (r *BpfdConfigReconciler) ReconcileBpfdConfig(ctx context.Context, req ctrl
 
 	if !bpfdConfig.DeletionTimestamp.IsZero() {
 		r.Logger.Info("Deleting bpfd daemon and config")
-		controllerutil.RemoveFinalizer(bpfdDeployment, bpfdOperatorFinalizer)
+		controllerutil.RemoveFinalizer(bpfdDeployment, internal.BpfdOperatorFinalizer)
 
 		err := r.Update(ctx, bpfdDeployment)
 		if err != nil {
@@ -121,7 +121,7 @@ func (r *BpfdConfigReconciler) ReconcileBpfdConfig(ctx context.Context, req ctrl
 			return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 		}
 
-		controllerutil.RemoveFinalizer(bpfdConfig, bpfdOperatorFinalizer)
+		controllerutil.RemoveFinalizer(bpfdConfig, internal.BpfdOperatorFinalizer)
 		err = r.Update(ctx, bpfdConfig)
 		if err != nil {
 			r.Logger.Error(err, "failed removing bpfd-operator finalizer from bpfd config")

--- a/bpfd-operator/controllers/bpfd-operator/configmap_test.go
+++ b/bpfd-operator/controllers/bpfd-operator/configmap_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/bpfd-dev/bpfd/bpfd-operator/internal"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -113,7 +114,7 @@ client_key = "/etc/bpfd/certs/bpfd-client/tls.key"
 	require.NoError(t, err)
 
 	// Check the bpfd-operator finalizer was successfully added
-	require.Contains(t, bpfdConfig.GetFinalizers(), bpfdOperatorFinalizer)
+	require.Contains(t, bpfdConfig.GetFinalizers(), internal.BpfdOperatorFinalizer)
 
 	// Second reconcile will create bpfd daemonset
 	res, err = r.Reconcile(ctx, req)

--- a/bpfd-operator/controllers/bpfd-operator/tc-program.go
+++ b/bpfd-operator/controllers/bpfd-operator/tc-program.go
@@ -104,7 +104,7 @@ func (r *TcProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return reconcileBpfProgram(ctx, r, tcProgram)
 }
 
-func (r *TcProgramReconciler) updateStatus(ctx context.Context, name string, cond ProgramConditionType, message string) (ctrl.Result, error) {
+func (r *TcProgramReconciler) updateStatus(ctx context.Context, name string, cond bpfdiov1alpha1.ProgramConditionType, message string) (ctrl.Result, error) {
 	// Sometimes we end up with a stale TcProgram due to races, do this
 	// get to ensure we're up to date before attempting a finalizer removal.
 	prog := &bpfdiov1alpha1.TcProgram{}

--- a/bpfd-operator/controllers/bpfd-operator/tc-program_test.go
+++ b/bpfd-operator/controllers/bpfd-operator/tc-program_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	bpfdiov1alpha1 "github.com/bpfd-dev/bpfd/bpfd-operator/apis/v1alpha1"
-	bpfdagent "github.com/bpfd-dev/bpfd/bpfd-operator/controllers/bpfd-agent"
 	internal "github.com/bpfd-dev/bpfd/bpfd-operator/internal"
 	testutils "github.com/bpfd-dev/bpfd/bpfd-operator/internal/test-utils"
 
@@ -94,7 +93,7 @@ func TestTcProgramReconcile(t *testing.T) {
 			Programs: map[string]map[string]string{bpfdProgId: {}},
 		},
 		Status: bpfdiov1alpha1.BpfProgramStatus{
-			Conditions: []metav1.Condition{bpfdagent.BpfProgCondLoaded.Condition()},
+			Conditions: []metav1.Condition{bpfdiov1alpha1.BpfProgCondLoaded.Condition()},
 		},
 	}
 
@@ -144,7 +143,7 @@ func TestTcProgramReconcile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the bpfd-operator finalizer was successfully added
-	require.Contains(t, tc.GetFinalizers(), bpfdOperatorFinalizer)
+	require.Contains(t, tc.GetFinalizers(), internal.BpfdOperatorFinalizer)
 
 	// Second reconcile should check bpfProgram Status and write Success condition to tcProgram Status
 	res, err = r.Reconcile(ctx, req)
@@ -159,6 +158,6 @@ func TestTcProgramReconcile(t *testing.T) {
 	err = cl.Get(ctx, types.NamespacedName{Name: tc.Name, Namespace: metav1.NamespaceAll}, tc)
 	require.NoError(t, err)
 
-	require.Equal(t, tc.Status.Conditions[0].Type, string(BpfProgConfigReconcileSuccess))
+	require.Equal(t, tc.Status.Conditions[0].Type, string(bpfdiov1alpha1.ProgramReconcileSuccess))
 
 }

--- a/bpfd-operator/controllers/bpfd-operator/tracepoint-program.go
+++ b/bpfd-operator/controllers/bpfd-operator/tracepoint-program.go
@@ -104,7 +104,7 @@ func (r *TracepointProgramReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return reconcileBpfProgram(ctx, r, tracepointProgram)
 }
 
-func (r *TracepointProgramReconciler) updateStatus(ctx context.Context, name string, cond ProgramConditionType, message string) (ctrl.Result, error) {
+func (r *TracepointProgramReconciler) updateStatus(ctx context.Context, name string, cond bpfdiov1alpha1.ProgramConditionType, message string) (ctrl.Result, error) {
 	// Sometimes we end up with a stale XdpProgram due to races, do this
 	// get to ensure we're up to date before attempting a finalizer removal.
 	prog := &bpfdiov1alpha1.TracepointProgram{}

--- a/bpfd-operator/controllers/bpfd-operator/tracepoint-program_test.go
+++ b/bpfd-operator/controllers/bpfd-operator/tracepoint-program_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	bpfdiov1alpha1 "github.com/bpfd-dev/bpfd/bpfd-operator/apis/v1alpha1"
-	bpfdagent "github.com/bpfd-dev/bpfd/bpfd-operator/controllers/bpfd-agent"
 	internal "github.com/bpfd-dev/bpfd/bpfd-operator/internal"
 	testutils "github.com/bpfd-dev/bpfd/bpfd-operator/internal/test-utils"
 
@@ -86,7 +85,7 @@ func TestTracepointProgramReconcile(t *testing.T) {
 			Programs: map[string]map[string]string{bpfdProgId: {}},
 		},
 		Status: bpfdiov1alpha1.BpfProgramStatus{
-			Conditions: []metav1.Condition{bpfdagent.BpfProgCondLoaded.Condition()},
+			Conditions: []metav1.Condition{bpfdiov1alpha1.BpfProgCondLoaded.Condition()},
 		},
 	}
 
@@ -136,7 +135,7 @@ func TestTracepointProgramReconcile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the bpfd-operator finalizer was successfully added
-	require.Contains(t, Tracepoint.GetFinalizers(), bpfdOperatorFinalizer)
+	require.Contains(t, Tracepoint.GetFinalizers(), internal.BpfdOperatorFinalizer)
 
 	// Second reconcile should check bpfProgram Status and write Success condition to tcProgram Status
 	res, err = r.Reconcile(ctx, req)
@@ -151,6 +150,6 @@ func TestTracepointProgramReconcile(t *testing.T) {
 	err = cl.Get(ctx, types.NamespacedName{Name: Tracepoint.Name, Namespace: metav1.NamespaceAll}, Tracepoint)
 	require.NoError(t, err)
 
-	require.Equal(t, Tracepoint.Status.Conditions[0].Type, string(BpfProgConfigReconcileSuccess))
+	require.Equal(t, Tracepoint.Status.Conditions[0].Type, string(bpfdiov1alpha1.ProgramReconcileSuccess))
 
 }

--- a/bpfd-operator/controllers/bpfd-operator/xdp-program.go
+++ b/bpfd-operator/controllers/bpfd-operator/xdp-program.go
@@ -106,7 +106,7 @@ func (r *XdpProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return reconcileBpfProgram(ctx, r, xdpProgram)
 }
 
-func (r *XdpProgramReconciler) updateStatus(ctx context.Context, name string, cond ProgramConditionType, message string) (ctrl.Result, error) {
+func (r *XdpProgramReconciler) updateStatus(ctx context.Context, name string, cond bpfdiov1alpha1.ProgramConditionType, message string) (ctrl.Result, error) {
 	// Sometimes we end up with a stale XdpProgram due to races, do this
 	// get to ensure we're up to date before attempting a finalizer removal.
 	prog := &bpfdiov1alpha1.XdpProgram{}

--- a/bpfd-operator/controllers/bpfd-operator/xdp-program_test.go
+++ b/bpfd-operator/controllers/bpfd-operator/xdp-program_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	bpfdiov1alpha1 "github.com/bpfd-dev/bpfd/bpfd-operator/apis/v1alpha1"
-	bpfdagent "github.com/bpfd-dev/bpfd/bpfd-operator/controllers/bpfd-agent"
 	internal "github.com/bpfd-dev/bpfd/bpfd-operator/internal"
 	testutils "github.com/bpfd-dev/bpfd/bpfd-operator/internal/test-utils"
 
@@ -91,7 +90,7 @@ func TestXdpProgramReconcile(t *testing.T) {
 			Programs: map[string]map[string]string{bpfdProgId: {}},
 		},
 		Status: bpfdiov1alpha1.BpfProgramStatus{
-			Conditions: []metav1.Condition{bpfdagent.BpfProgCondLoaded.Condition()},
+			Conditions: []metav1.Condition{bpfdiov1alpha1.BpfProgCondLoaded.Condition()},
 		},
 	}
 
@@ -141,7 +140,7 @@ func TestXdpProgramReconcile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the bpfd-operator finalizer was successfully added
-	require.Contains(t, Xdp.GetFinalizers(), bpfdOperatorFinalizer)
+	require.Contains(t, Xdp.GetFinalizers(), internal.BpfdOperatorFinalizer)
 
 	// Second reconcile should check bpfProgram Status and write Success condition to tcProgram Status
 	res, err = r.Reconcile(ctx, req)
@@ -156,6 +155,6 @@ func TestXdpProgramReconcile(t *testing.T) {
 	err = cl.Get(ctx, types.NamespacedName{Name: Xdp.Name, Namespace: metav1.NamespaceAll}, Xdp)
 	require.NoError(t, err)
 
-	require.Equal(t, Xdp.Status.Conditions[0].Type, string(BpfProgConfigReconcileSuccess))
+	require.Equal(t, Xdp.Status.Conditions[0].Type, string(bpfdiov1alpha1.ProgramReconcileSuccess))
 
 }

--- a/bpfd-operator/internal/constants.go
+++ b/bpfd-operator/internal/constants.go
@@ -82,3 +82,13 @@ func (p SupportedProgramType) String() string {
 		return ""
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Finalizers
+// -----------------------------------------------------------------------------
+
+const (
+	// BpfdOperatorFinalizer is the finalizer that holds a BPF program from
+	// deletion until cleanup can be performed.
+	BpfdOperatorFinalizer = "bpfd.io.operator/finalizer"
+)

--- a/bpfd-operator/pkg/helpers/helpers.go
+++ b/bpfd-operator/pkg/helpers/helpers.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	bpfdoperator "github.com/bpfd-dev/bpfd/bpfd-operator/controllers/bpfd-operator"
+	bpfdiov1alpha1 "github.com/bpfd-dev/bpfd/bpfd-operator/apis/v1alpha1"
 )
 
 const (
@@ -275,7 +275,7 @@ func isTcbpfdProgLoaded(c *bpfdclientset.Clientset, progConfName string) wait.Co
 
 		condition := bpfProgConfig.Status.Conditions[recentIdx]
 
-		if condition.Type != string(bpfdoperator.BpfProgConfigReconcileSuccess) {
+		if condition.Type != string(bpfdiov1alpha1.ProgramReconcileSuccess) {
 			log.Info("tcProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condition.Type)
 			return false, nil
 		}
@@ -305,7 +305,7 @@ func isTracepointbpfdProgLoaded(c *bpfdclientset.Clientset, progConfName string)
 
 		condition := bpfProgConfig.Status.Conditions[recentIdx]
 
-		if condition.Type != string(bpfdoperator.BpfProgConfigReconcileSuccess) {
+		if condition.Type != string(bpfdiov1alpha1.ProgramReconcileSuccess) {
 			log.Info("tracepointProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condition.Type)
 			return false, nil
 		}
@@ -335,7 +335,7 @@ func isXdpbpfdProgLoaded(c *bpfdclientset.Clientset, progConfName string) wait.C
 
 		condition := bpfProgConfig.Status.Conditions[recentIdx]
 
-		if condition.Type != string(bpfdoperator.BpfProgConfigReconcileSuccess) {
+		if condition.Type != string(bpfdiov1alpha1.ProgramReconcileSuccess) {
 			log.Info("xdpProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condition.Type)
 			return false, nil
 		}


### PR DESCRIPTION
This moves the cluster and node level condition types into the public API, as a first step for #430.

Partially resolves #430.
