### PR TITLE
bpfd: Use XDP dispatcher v2

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -3,14 +3,14 @@ name: bpfd-image-build
 on:
   push:
     branches: [ main ]
-    tags:        
+    tags:
       - 'v*'
 
   pull_request:
     paths: [ '.github/workflows/image-build.yaml' ]
 
 env:
-  REGISTRY: quay.io 
+  REGISTRY: quay.io
   BPFD_REPOSITORY: bpfd
   BPFD_USERSPACE_REPOSITORY: bpfd-userspace
   BPFD_BYTECODE_REPOSITORY: bpfd-bytecode
@@ -29,10 +29,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: image-repositories
     steps:
-    - name: Check out rust source code
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        repository: libbpf/libbpf
+        path: libbpf
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Install libelf-dev
+      run: sudo apt-get install -y linux-headers-generic clang lldb lld libelf-dev gcc-multilib
 
-## Build quay.io/bpfd images
     - name: Login to quay.io/bpfd
       uses: redhat-actions/podman-login@v1
       if: ${{ github.event_name == 'push' }}
@@ -41,6 +49,48 @@ jobs:
         username: ${{ secrets.BPFD_USERNAME }}
         password: ${{ secrets.BPFD_ROBOT_TOKEN }}
 
+## Build XDP dispatchers
+    - name: Build eBPF
+      run: |
+        cargo xtask build-ebpf --libbpf-dir ./libbpf
+
+    - name: Build xdp-dispatcher:v1 image
+      id: build-xdp-dispatcher-v1-bytecode
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: xdp_dispatcher
+        tags: v1
+        context: .
+        containerfiles: |
+          Containerfile.xdp_dispatcher_v1
+
+    - name: Push xdp-dispatcher:v1 to quay.io/bpfd-bytecode
+      uses: redhat-actions/push-to-registry@v2
+      if: ${{ github.event_name == 'push' }}
+      with:
+        image: ${{ steps.build-xdp-dispatcher-v1-bytecode.outputs.image }}
+        tags: ${{ steps.build-xdp-dispatcher-v1-bytecode.outputs.tags }}
+        registry: ${{ env.REGISTRY }}/${{ env.BPFD_REPOSITORY }}
+
+    - name: Build xdp-dispatcher:v2 image
+      id: build-xdp-dispatcher-v2-bytecode
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: xdp_dispatcher
+        tags: v2
+        context: .
+        containerfiles: |
+          Containerfile.xdp_dispatcher_v2
+
+    - name: Push xdp-dispatcher:v2 to quay.io/bpfd-bytecode
+      uses: redhat-actions/push-to-registry@v2
+      if: ${{ github.event_name == 'push' }}
+      with:
+        image: ${{ steps.build-xdp-dispatcher-v2-bytecode.outputs.image }}
+        tags: ${{ steps.build-xdp-dispatcher-v2-bytecode.outputs.tags }}
+        registry: ${{ env.REGISTRY }}/${{ env.BPFD_REPOSITORY }}
+
+## Build quay.io/bpfd images
     - name: Extract metadata (tags, labels) for bpfd image
       id: meta-bpfd
       uses: docker/metadata-action@v4.4.0
@@ -92,7 +142,7 @@ jobs:
         labels: ${{ steps.meta-bpfctl.outputs.labels }}
         containerfiles: |
           ./packaging/container-deployment/Containerfile.bpfctl
-    
+
     - name: Push bpfctl to quay.io/bpfd
       uses: redhat-actions/push-to-registry@v2
       if: ${{ github.event_name == 'push' }}
@@ -123,7 +173,7 @@ jobs:
         context: ./
         containerfiles: |
           ./bpfd-operator/Containerfile.bpfd-agent
-    
+
     - name: Push bpfd-agent to quay.io/bpfd
       uses: redhat-actions/push-to-registry@v2
       if: ${{ github.event_name == 'push' }}
@@ -131,7 +181,7 @@ jobs:
         image: ${{ steps.build-bpfd-agent.outputs.image }}
         tags: ${{ steps.build-bpfd-agent.outputs.tags }}
         registry: ${{ env.REGISTRY }}/${{ env.BPFD_REPOSITORY }}
-    
+
     - name: Extract metadata (tags, labels) for bpfd-operator image
       id: meta-bpfd-operator
       uses: docker/metadata-action@v4.4.0
@@ -256,7 +306,7 @@ jobs:
         context: ./
         containerfiles: |
           ./examples/go-tc-counter/container-deployment/Containerfile.go-tc-counter
- 
+
     - name: Push go-tc-counter to quay.io/bpfd-userspace
       uses: redhat-actions/push-to-registry@v2
       if: ${{ github.event_name == 'push' }}
@@ -340,7 +390,7 @@ jobs:
         image: ${{ steps.build-go-xdp-counter-bytecode.outputs.image }}
         tags: ${{ steps.build-go-xdp-counter-bytecode.outputs.tags }}
         registry: ${{ env.REGISTRY }}/${{ env.BPFD_BYTECODE_REPOSITORY }}
-      
+
     - name: Extract metadata (tags, labels) for go-tc-counter-bytecode image
       id: meta-go-tc-counter-bytecode
       uses: docker/metadata-action@v4.4.0

--- a/Containerfile.xdp_dispatcher_v1
+++ b/Containerfile.xdp_dispatcher_v1
@@ -1,0 +1,7 @@
+FROM scratch
+
+COPY  .output/xdp_dispatcher_v1.bpf.o dispatcher.o
+LABEL io.ebpf.program_type xdp
+LABEL io.ebpf.filename dispatcher.o
+LABEL io.ebpf.program_name xdp_dispatcher_v1
+LABEL io.ebpf.section_name xdp

--- a/Containerfile.xdp_dispatcher_v2
+++ b/Containerfile.xdp_dispatcher_v2
@@ -1,0 +1,7 @@
+FROM scratch
+
+COPY  .output/xdp_dispatcher_v2.bpf.o dispatcher.o
+LABEL io.ebpf.program_type xdp
+LABEL io.ebpf.filename dispatcher.o
+LABEL io.ebpf.program_name xdp_dispatcher_v2
+LABEL io.ebpf.section_name xdp

--- a/bpf/xdp_dispatcher_v1.bpf.c
+++ b/bpf/xdp_dispatcher_v1.bpf.c
@@ -1,0 +1,198 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of bpfd */
+#include <linux/bpf.h>
+#include <linux/in.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+
+#define XDP_METADATA_SECTION "xdp_metadata"
+#define XDP_DISPATCHER_VERSION 1
+#define XDP_DISPATCHER_RETVAL 31
+#define MAX_DISPATCHER_ACTIONS 10
+
+struct xdp_dispatcher_conf {
+	__u8 num_progs_enabled;
+	__u32 chain_call_actions[MAX_DISPATCHER_ACTIONS];
+	__u32 run_prios[MAX_DISPATCHER_ACTIONS];
+};
+volatile const struct xdp_dispatcher_conf conf = {};
+
+__attribute__ ((noinline))
+int prog0(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int prog1(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int prog2(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int prog3(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int prog4(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int prog5(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int prog6(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int prog7(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int prog8(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int prog9(struct xdp_md *ctx) {
+    volatile int ret = XDP_DISPATCHER_RETVAL;
+
+    if (!ctx)
+        return XDP_ABORTED;
+    return ret;
+}
+
+__attribute__ ((noinline))
+int compat_test(struct xdp_md *ctx) {
+        volatile int ret = XDP_DISPATCHER_RETVAL;
+
+        if (!ctx)
+          return XDP_ABORTED;
+        return ret;
+}
+
+
+SEC("xdp")
+int xdp_dispatcher(struct xdp_md *ctx)
+{
+        __u8 num_progs_enabled = conf.num_progs_enabled;
+        int ret;
+
+        if (num_progs_enabled < 1)
+            goto out;
+        ret = prog0(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[0]))
+            return ret;
+
+        if (num_progs_enabled < 2)
+            goto out;
+        ret = prog1(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[1]))
+            return ret;
+
+        if (num_progs_enabled < 3)
+            goto out;
+        ret = prog2(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[2]))
+            return ret;
+
+        if (num_progs_enabled < 4)
+            goto out;
+        ret = prog3(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[3]))
+            return ret;
+
+        if (num_progs_enabled < 5)
+            goto out;
+        ret = prog4(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[4]))
+            return ret;
+
+        if (num_progs_enabled < 6)
+            goto out;
+        ret = prog5(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[5]))
+            return ret;
+
+        if (num_progs_enabled < 7)
+            goto out;
+        ret = prog6(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[6]))
+            return ret;
+
+        if (num_progs_enabled < 8)
+            goto out;
+        ret = prog7(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[7]))
+            return ret;
+
+        if (num_progs_enabled < 9)
+            goto out;
+        ret = prog8(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[8]))
+            return ret;
+
+        if (num_progs_enabled < 10)
+            goto out;
+        ret = prog9(ctx);
+        if (!((1U << ret) & conf.chain_call_actions[9]))
+            return ret;
+
+        /* keep a reference to the compat_test() function so we can use it
+         * as an freplace target in xdp_multiprog__check_compat() in libxdp
+         */
+        if (num_progs_enabled < 11)
+                goto out;
+        ret = compat_test(ctx);
+out:
+        return XDP_PASS;
+}
+
+char _license[] SEC("license") = "GPL";
+
+__uint(dispatcher_version, XDP_DISPATCHER_VERSION) SEC(XDP_METADATA_SECTION);

--- a/bpf/xdp_dispatcher_v2.bpf.c
+++ b/bpf/xdp_dispatcher_v2.bpf.c
@@ -6,16 +6,33 @@
 #include <bpf/bpf_endian.h>
 
 #define XDP_METADATA_SECTION "xdp_metadata"
-#define XDP_DISPATCHER_VERSION 1
+#define XDP_DISPATCHER_VERSION 2
+#define XDP_DISPATCHER_MAGIC 236
 #define XDP_DISPATCHER_RETVAL 31
 #define MAX_DISPATCHER_ACTIONS 10
 
-struct xdp_dispatcher_config {
-	__u8 num_progs_enabled;
+struct xdp_dispatcher_conf {
+	__u8 magic;                         /* Set to XDP_DISPATCHER_MAGIC */
+	__u8 dispatcher_version;            /* Set to XDP_DISPATCHER_VERSION */
+	__u8 num_progs_enabled;             /* Number of active program slots */
+	__u8 is_xdp_frags;                  /* Whether this dispatcher is loaded with XDP frags support */
 	__u32 chain_call_actions[MAX_DISPATCHER_ACTIONS];
 	__u32 run_prios[MAX_DISPATCHER_ACTIONS];
+	__u32 program_flags[MAX_DISPATCHER_ACTIONS];
 };
-volatile const struct xdp_dispatcher_config CONFIG = {};
+
+/* While 'const volatile' sounds a little like an oxymoron, there's reason
+ * behind the madness:
+ *
+ * - const places the data in rodata, where libbpf will mark it as read-only and
+ *   frozen on program load, letting the kernel do dead code elimination based
+ *   on the values.
+ *
+ * - volatile prevents the compiler from optimising away the checks based on the
+ *   compile-time value of the variables, which is important since we will be
+ *   changing the values before loading the program into the kernel.
+ */
+static volatile const struct xdp_dispatcher_conf conf = {};
 
 __attribute__ ((noinline))
 int prog0(struct xdp_md *ctx) {
@@ -117,70 +134,70 @@ int compat_test(struct xdp_md *ctx) {
 }
 
 
-SEC("xdp/dispatcher")
+SEC("xdp")
 int xdp_dispatcher(struct xdp_md *ctx)
 {
-        __u8 num_progs_enabled = CONFIG.num_progs_enabled;
+        __u8 num_progs_enabled = conf.num_progs_enabled;
         int ret;
 
         if (num_progs_enabled < 1)
             goto out;
         ret = prog0(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[0]))
+        if (!((1U << ret) & conf.chain_call_actions[0]))
             return ret;
 
         if (num_progs_enabled < 2)
             goto out;
         ret = prog1(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[1]))
+        if (!((1U << ret) & conf.chain_call_actions[1]))
             return ret;
 
         if (num_progs_enabled < 3)
             goto out;
         ret = prog2(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[2]))
+        if (!((1U << ret) & conf.chain_call_actions[2]))
             return ret;
 
         if (num_progs_enabled < 4)
             goto out;
         ret = prog3(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[3]))
+        if (!((1U << ret) & conf.chain_call_actions[3]))
             return ret;
 
         if (num_progs_enabled < 5)
             goto out;
         ret = prog4(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[4]))
+        if (!((1U << ret) & conf.chain_call_actions[4]))
             return ret;
 
         if (num_progs_enabled < 6)
             goto out;
         ret = prog5(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[5]))
+        if (!((1U << ret) & conf.chain_call_actions[5]))
             return ret;
 
         if (num_progs_enabled < 7)
             goto out;
         ret = prog6(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[6]))
+        if (!((1U << ret) & conf.chain_call_actions[6]))
             return ret;
 
         if (num_progs_enabled < 8)
             goto out;
         ret = prog7(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[7]))
+        if (!((1U << ret) & conf.chain_call_actions[7]))
             return ret;
 
         if (num_progs_enabled < 9)
             goto out;
         ret = prog8(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[8]))
+        if (!((1U << ret) & conf.chain_call_actions[8]))
             return ret;
 
         if (num_progs_enabled < 10)
             goto out;
         ret = prog9(ctx);
-        if (!((1U << ret) & CONFIG.chain_call_actions[9]))
+        if (!((1U << ret) & conf.chain_call_actions[9]))
             return ret;
 
         /* keep a reference to the compat_test() function so we can use it
@@ -194,5 +211,4 @@ out:
 }
 
 char _license[] SEC("license") = "GPL";
-
 __uint(dispatcher_version, XDP_DISPATCHER_VERSION) SEC(XDP_METADATA_SECTION);

--- a/bpfd/src/dispatcher_config.rs
+++ b/bpfd/src/dispatcher_config.rs
@@ -10,9 +10,33 @@ pub(crate) const MAX_DISPATCHER_ACTIONS: usize = 10;
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub(crate) struct XdpDispatcherConfig {
+    pub magic: u8,
+    pub dispatcher_version: u8,
     pub num_progs_enabled: u8,
+    pub is_xdp_frags: u8,
     pub chain_call_actions: [u32; MAX_DISPATCHER_ACTIONS],
     pub run_prios: [u32; MAX_DISPATCHER_ACTIONS],
+    pub program_flags: [u32; MAX_DISPATCHER_ACTIONS],
+}
+
+impl XdpDispatcherConfig {
+    pub(crate) fn new(
+        num_progs_enabled: u8,
+        is_xdp_frags: u8,
+        chain_call_actions: [u32; MAX_DISPATCHER_ACTIONS],
+        run_prios: [u32; MAX_DISPATCHER_ACTIONS],
+        program_flags: [u32; MAX_DISPATCHER_ACTIONS],
+    ) -> Self {
+        Self {
+            magic: 236u8,
+            dispatcher_version: 2u8,
+            num_progs_enabled,
+            is_xdp_frags,
+            chain_call_actions,
+            run_prios,
+            program_flags,
+        }
+    }
 }
 
 unsafe impl aya::Pod for XdpDispatcherConfig {}

--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -115,7 +115,7 @@ pub fn build_ebpf(opts: Options) -> anyhow::Result<()> {
 
     build_ebpf_files(src_path, include_path.clone(), out_path)?;
 
-    // build integration test eBPF code (reuse includ_path)
+    // build integration test eBPF code (reuse include_path)
     let mut src_path = PathBuf::from(WORKSPACE_ROOT.to_string());
     src_path.push("tests/integration-test/bpf");
 


### PR DESCRIPTION
This adds a new XDP dispatcher with the adjusted XdpDispatcherConfig struct to work with the v2 of the dispatcher per the libxdp protocol spec.

Note: This doesn't (yet) handle frags support, which is something that will be implemented later on - which was the primary motivation for dispatcher v2.

Updates: #319 
Updates: #533 (Adds dispatcher image push)