### PR TITLE
Add e2e testing to bpfd integration test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
         run: systemctl is-active bpfd
 
       - name: Verify the bpfctl can reach bpfd
-        run: sudo bpfctl --help
+        run: sudo bpfctl list
 
       - name: Stop the bpfd systemd service
         run: sudo systemctl stop bpfd

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,0 +1,61 @@
+# Testing
+
+This document describes the automated testing that is done for each pull request
+submitted to [bpfd](https://github.com/bpfd-dev/bpfd).
+
+## Unit Testing
+
+Unit testing is executed as part of the `build` job  by running the `cargo test`
+command in the top-level bpfd directory.
+
+## Go Example Tests
+
+Tests are run for each of the example programs found in directory `examples`
+
+Detailed description TBD
+
+## Basic Integration Tests
+
+Basic integration tests are executed by running the `cargo xtask
+integration-test` command in the top-level bpfd directory.
+
+The integration tests start a `bpfd` daemon process, and issue `bpfctl` commands
+to verify a range of functionality.  For XDP and TC programs that are installed
+on network interfaces, the integration test code creates a test network
+namespace connected to the host by a veth pair on which the programs are
+attached. The test code uses the IP subnet 172.37.37.1/24 for the namespace. If
+that address conflicts with an existing network on the host, it can be changed
+by setting the `BPFD_IP_PREFIX` environment variable to one that is available as
+shown below.
+
+```bash
+export BPFD_IP_PREFIX="192.168.50"
+```
+
+There are two categories of integration tests: basic and e2e.  The basic tests
+verify basic `bpfctl` functionality such as loading, listing, and unloading
+programs.  The e2e tests verify more advanced functionality such as the setting
+of global variables, priority, and proceed-on by installing the programs,
+creating traffic if needed, and examining logs to confirm that things are
+running as expected.
+
+eBPF test programs are loaded from container images stored on
+[quay.io](https://quay.io/repository/bpfd-bytecode/tc_pass). The source code for
+the eBPF test programs can be found in the `tests/integration-test/bpf`
+directory.  These programs are compiled by executing `cargo xtask build-ebpf
+--libbpf-dir <libbpf dir>`
+
+The `bpf` directory also contains a script called `build_push_images.sh` that
+can be used to build and push new images to quay if the code is changed.  We
+plan to push the images automatically when code gets merged ([issue
+\#533](<https://github.com/bpfd-dev/bpfd/issues/533>)). However, it's still
+useful to be able to push them manually sometimes. For example, when a new test
+case requires that both the eBPF and integration code be changed together.  It
+is also a useful template for new eBPF test code that needs to be pushed.
+However, as a word of caution, be aware that existing integration tests will
+start using the new programs immediately, so this should only be done if the
+modified program is backward compatible.
+
+## Kubernetes Integration Tests
+
+Detailed decription TBD

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
     - Linux Capabilities: developer-guide/linux-capabilities.md
     - Logging: developer-guide/logging.md
     - Configuration: developer-guide/configuration.md
+    - Testing: developer-guide/testing.md
   - Community:
     - Meetings: governance/MEETINGS.md
     - Governance: governance/GOVERNANCE.md

--- a/tests/integration-test/bpf/build_push_images.sh
+++ b/tests/integration-test/bpf/build_push_images.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+docker login quay.io
+
+docker build \
+ --build-arg PROGRAM_NAME=xdp_pass \
+ --build-arg SECTION_NAME=pass \
+ --build-arg PROGRAM_TYPE=xdp \
+ --build-arg BYTECODE_FILENAME=xdp_pass.bpf.o \
+ --build-arg KERNEL_COMPILE_VER=$(uname -r) \
+ -f ../../../packaging/container-deployment/Containerfile.bytecode \
+ ./.output -t quay.io/bpfd-bytecode/xdp_pass:latest
+
+docker push quay.io/bpfd-bytecode/xdp_pass
+
+docker build \
+ --build-arg PROGRAM_NAME=tc_pass \
+ --build-arg SECTION_NAME=pass \
+ --build-arg PROGRAM_TYPE=tc \
+ --build-arg BYTECODE_FILENAME=tc_pass.bpf.o \
+ --build-arg KERNEL_COMPILE_VER=$(uname -r) \
+ -f ../../../packaging/container-deployment/Containerfile.bytecode \
+ ./.output -t quay.io/bpfd-bytecode/tc_pass:latest
+
+docker push quay.io/bpfd-bytecode/tc_pass
+
+docker build \
+ --build-arg PROGRAM_NAME=tracepoint \
+ --build-arg SECTION_NAME=sys_enter_openat \
+ --build-arg PROGRAM_TYPE=tracepoint \
+ --build-arg BYTECODE_FILENAME=tp_openat.bpf.o \
+ --build-arg KERNEL_COMPILE_VER=$(uname -r) \
+ -f ../../../packaging/container-deployment//Containerfile.bytecode \
+ ./.output -t quay.io/bpfd-bytecode/tracepoint:latest
+
+docker push quay.io/bpfd-bytecode/tracepoint
+

--- a/tests/integration-test/src/tests/basic.rs
+++ b/tests/integration-test/src/tests/basic.rs
@@ -1,35 +1,57 @@
-use std::{path::PathBuf, process::exit, thread::sleep, time::Duration};
+use std::path::PathBuf;
 
 use bpfd_api::util::directories::{RTDIR_FS_TC_INGRESS, RTDIR_FS_XDP};
-use log::{debug, error};
+use log::debug;
 use rand::Rng;
 
 use super::{integration_test, IntegrationTest};
 use crate::tests::utils::*;
 
 #[integration_test]
-fn test_load_unload() {
-    let guard = start_bpfd().unwrap();
+fn test_load_unload_xdp() {
+    let _namespace_guard = create_namespace().unwrap();
+    let _ping_guard = start_ping().unwrap();
+    let bpfd_guard = start_bpfd().unwrap();
 
-    let bpfd_iface = read_iface_env();
-    if !iface_exists(bpfd_iface) {
-        error!(
-            "Interface {} not found, specify a usable interface with the env BPFD_IFACE",
-            bpfd_iface
-        );
-        exit(0)
-    }
+    assert!(iface_exists(DEFAULT_BPFD_IFACE));
 
     debug!("Installing xdp_pass programs");
+
+    let globals = vec!["GLOBAL_u8=61", "GLOBAL_u32=0D0C0B0A"];
+
+    let proceed_on = vec![
+        "aborted",
+        "drop",
+        "pass",
+        "tx",
+        "redirect",
+        "dispatcher_return",
+    ];
+
     let mut uuids = vec![];
     // Install a few xdp programs
-    let uuid = add_xdp_pass(bpfd_iface, 75);
+    let uuid = add_xdp_pass(
+        DEFAULT_BPFD_IFACE,
+        75,
+        Some(globals.clone()),
+        Some(proceed_on.clone()),
+    );
     uuids.push(uuid.unwrap());
-    let uuid = add_xdp_pass(bpfd_iface, 50);
+    let uuid = add_xdp_pass(
+        DEFAULT_BPFD_IFACE,
+        50,
+        Some(globals.clone()),
+        Some(proceed_on.clone()),
+    );
     uuids.push(uuid.unwrap());
-    let uuid = add_xdp_pass(bpfd_iface, 100);
+    let uuid = add_xdp_pass(
+        DEFAULT_BPFD_IFACE,
+        100,
+        Some(globals.clone()),
+        Some(proceed_on.clone()),
+    );
     uuids.push(uuid.unwrap());
-    let uuid = add_xdp_pass(bpfd_iface, 25);
+    let uuid = add_xdp_pass(DEFAULT_BPFD_IFACE, 25, None, None);
     uuids.push(uuid.unwrap());
     assert_eq!(uuids.len(), 4);
 
@@ -41,8 +63,8 @@ fn test_load_unload() {
         .is_some());
 
     // Verify rule persistence between restarts
-    drop(guard);
-    let _guard = start_bpfd().unwrap();
+    drop(bpfd_guard);
+    let _bpfd_guard = start_bpfd().unwrap();
 
     // Verify bpfctl list contains the uuids of each program
     let bpfctl_list = bpfd_list().unwrap();
@@ -52,7 +74,6 @@ fn test_load_unload() {
 
     // Delete the installed programs
     debug!("Deleting bpfd programs");
-    sleep(Duration::from_secs(2));
     for id in uuids.iter() {
         bpfd_del_program(id)
     }
@@ -74,24 +95,42 @@ fn test_load_unload() {
 
 #[integration_test]
 fn test_load_unload_tc() {
-    let _guard = start_bpfd().unwrap();
+    let _namespace_guard = create_namespace().unwrap();
+    let _ping_guard = start_ping().unwrap();
+    let _bpfd_guard = start_bpfd().unwrap();
 
-    let bpfd_iface = read_iface_env();
-    if !iface_exists(bpfd_iface) {
-        error!(
-            "Interface {} not found, specify a usable interface with the env BPFD_IFACE",
-            bpfd_iface
-        );
-        exit(0)
-    }
+    assert!(iface_exists(DEFAULT_BPFD_IFACE));
 
-    debug!("Installing tc_pass programs");
+    debug!("Installing ingress tc programs");
+
+    let globals = vec!["GLOBAL_u8=61", "GLOBAL_u32=0D0C0B0A"];
+
+    let proceed_on = vec![
+        "unspec",
+        "ok",
+        "reclassify",
+        "shot",
+        "pipe",
+        "stolen",
+        "queued",
+        "repeat",
+        "redirect",
+        "trap",
+        "dispatcher_return",
+    ];
+
     let mut uuids = vec![];
     let mut rng = rand::thread_rng();
     // Install a few tc programs
     for _ in 0..10 {
         let priority = rng.gen_range(1..255);
-        let uuid = add_tc_pass(bpfd_iface, priority);
+        let uuid = add_tc_pass(
+            "ingress",
+            DEFAULT_BPFD_IFACE,
+            priority,
+            Some(globals.clone()),
+            Some(proceed_on.clone()),
+        );
         uuids.push(uuid.unwrap());
     }
     assert_eq!(uuids.len(), 10);
@@ -103,7 +142,7 @@ fn test_load_unload_tc() {
     }
 
     // Verify TC filter is using correct priority
-    let output = tc_filter_list(bpfd_iface).unwrap();
+    let output = tc_filter_list(DEFAULT_BPFD_IFACE).unwrap();
     assert!(output.contains("pref 50"));
     assert!(output.contains("handle 0x2"));
 
@@ -116,7 +155,6 @@ fn test_load_unload_tc() {
 
     // Delete the installed programs
     debug!("Deleting bpfd programs");
-    sleep(Duration::from_secs(2));
     for id in uuids.iter() {
         bpfd_del_program(id)
     }
@@ -135,23 +173,25 @@ fn test_load_unload_tc() {
         .next()
         .is_none());
 
-    let output = tc_filter_list(bpfd_iface).unwrap();
+    let output = tc_filter_list(DEFAULT_BPFD_IFACE).unwrap();
     assert!(output.trim().is_empty());
 }
 
 #[integration_test]
 fn test_load_unload_tracepoint() {
-    let _guard = start_bpfd().unwrap();
+    let _bpfd_guard = start_bpfd().unwrap();
 
     debug!("Installing tracepoint programs");
-    let uuid = add_tracepoint().unwrap();
+
+    let globals = vec!["GLOBAL_u8=61", "GLOBAL_u32=0D0C0B0A"];
+
+    let uuid = add_tracepoint(Some(globals)).unwrap();
     // Verify bpfctl list contains the uuids of each program
     let bpfctl_list = bpfd_list().unwrap();
     assert!(bpfctl_list.contains(uuid.trim()));
 
     // Delete the installed program
     debug!("Deleting bpfd programs");
-    sleep(Duration::from_secs(2));
     bpfd_del_program(&uuid);
 
     // Verify bpfctl list does not contain the uuids of the deleted programs

--- a/tests/integration-test/src/tests/e2e.rs
+++ b/tests/integration-test/src/tests/e2e.rs
@@ -1,0 +1,410 @@
+use std::{path::PathBuf, thread::sleep, time::Duration};
+
+use bpfd_api::util::directories::{RTDIR_FS_TC_EGRESS, RTDIR_FS_TC_INGRESS, RTDIR_FS_XDP};
+use log::debug;
+
+use super::{integration_test, IntegrationTest};
+use crate::tests::utils::*;
+
+const GLOBAL_1: &str = "GLOBAL_u8=25";
+const GLOBAL_2: &str = "GLOBAL_u8=29";
+const GLOBAL_3: &str = "GLOBAL_u8=2B";
+const GLOBAL_4: &str = "GLOBAL_u8=35";
+const GLOBAL_5: &str = "GLOBAL_u8=3B";
+const GLOBAL_6: &str = "GLOBAL_u8=3D";
+
+const XDP_GLOBAL_1_LOG: &str = "bpf_trace_printk: XDP: GLOBAL_u8: 0x25";
+const XDP_GLOBAL_2_LOG: &str = "bpf_trace_printk: XDP: GLOBAL_u8: 0x29";
+const XDP_GLOBAL_3_LOG: &str = "bpf_trace_printk: XDP: GLOBAL_u8: 0x2B";
+const TC_ING_GLOBAL_1_LOG: &str = "bpf_trace_printk:  TC: GLOBAL_u8: 0x25";
+const TC_ING_GLOBAL_2_LOG: &str = "bpf_trace_printk:  TC: GLOBAL_u8: 0x29";
+const TC_ING_GLOBAL_3_LOG: &str = "bpf_trace_printk:  TC: GLOBAL_u8: 0x2B";
+const TC_EG_GLOBAL_4_LOG: &str = "bpf_trace_printk:  TC: GLOBAL_u8: 0x35";
+const TC_EG_GLOBAL_5_LOG: &str = "bpf_trace_printk:  TC: GLOBAL_u8: 0x3B";
+const TC_EG_GLOBAL_6_LOG: &str = "bpf_trace_printk:  TC: GLOBAL_u8: 0x3D";
+const TRACEPOINT_GLOBAL_1_LOG: &str = "bpf_trace_printk:  TP: GLOBAL_u8: 0x25";
+
+#[integration_test]
+fn test_proceed_on_xdp() {
+    let _namespace_guard = create_namespace().unwrap();
+    let _ping_guard = start_ping().unwrap();
+    let trace_guard = start_trace_pipe().unwrap();
+    let _bpfd_guard = start_bpfd().unwrap();
+
+    assert!(iface_exists(DEFAULT_BPFD_IFACE));
+
+    let mut uuids = vec![];
+
+    debug!("Installing 1st xdp program");
+    let uuid = add_xdp_pass(
+        DEFAULT_BPFD_IFACE,
+        75,
+        Some([GLOBAL_1, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        None,
+    )
+    .unwrap();
+    uuids.push(uuid);
+
+    debug!("wait for some traffic to generate logs...");
+    sleep(Duration::from_secs(2));
+
+    let ping_log = read_ping_log().unwrap();
+    // Make sure we've had some pings
+    assert!(ping_log.lines().count() > 2);
+
+    // Make sure the first programs are running and logging
+    let trace_pipe_log = read_trace_pipe_log().unwrap();
+    assert!(!trace_pipe_log.is_empty());
+    assert!(trace_pipe_log.contains(XDP_GLOBAL_1_LOG));
+
+    // Install a 2nd xdp program with a higher priority that doesn't proceed on
+    // "pass", which this program will return.  This should prevent the first
+    // program from being executed.
+    debug!("Installing 2nd xdp program");
+    let uuid = add_xdp_pass(
+        DEFAULT_BPFD_IFACE,
+        50,
+        Some([GLOBAL_2, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        Some(["drop", "dispatcher_return"].to_vec()),
+    )
+    .unwrap();
+    uuids.push(uuid);
+
+    debug!("Clear the trace_pipe_log");
+    drop(trace_guard);
+    let trace_guard = start_trace_pipe().unwrap();
+
+    debug!("wait for some traffic to generate logs...");
+    sleep(Duration::from_secs(2));
+
+    // Make sure we have logs from the 2nd program and not from the 1st program.
+    let trace_pipe_log = read_trace_pipe_log().unwrap();
+    assert!(!trace_pipe_log.is_empty());
+    assert!(!trace_pipe_log.contains(XDP_GLOBAL_1_LOG));
+    assert!(trace_pipe_log.contains(XDP_GLOBAL_2_LOG));
+
+    // Install a 3rd xdp program with a higher priority that has proceed on
+    // "pass", which this program will return.  We should see logs from the 2nd
+    // and 3rd programs, but still not the first.
+    debug!("Installing 3rd xdp program");
+    let uuid = add_xdp_pass(
+        DEFAULT_BPFD_IFACE,
+        50,
+        Some([GLOBAL_3, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        Some(["pass", "dispatcher_return"].to_vec()),
+    )
+    .unwrap();
+    uuids.push(uuid);
+
+    debug!("Clear the trace_pipe_log");
+    drop(trace_guard);
+    let _trace_guard = start_trace_pipe().unwrap();
+
+    debug!("wait for some traffic to generate logs...");
+    sleep(Duration::from_secs(2));
+
+    // Make sure we have logs from the 2nd & 3rd programs, but not from the 1st
+    // program.
+    let trace_pipe_log = read_trace_pipe_log().unwrap();
+    assert!(!trace_pipe_log.is_empty());
+    assert!(!trace_pipe_log.contains(XDP_GLOBAL_1_LOG));
+    assert!(trace_pipe_log.contains(XDP_GLOBAL_2_LOG));
+    assert!(trace_pipe_log.contains(XDP_GLOBAL_3_LOG));
+    debug!("Successfully completed xdp proceed-on test");
+
+    // Delete the installed programs
+    debug!("Deleting bpfd programs");
+    for id in uuids.iter() {
+        bpfd_del_program(id)
+    }
+
+    // Verify bpfctl list does not contain the uuids of the deleted programs
+    // and that there are no panics if bpfctl does not contain any programs.
+    let bpfctl_list = bpfd_list().unwrap();
+    for id in uuids.iter() {
+        assert!(!bpfctl_list.contains(id));
+    }
+}
+
+#[integration_test]
+fn test_proceed_on_tc() {
+    let _namespace_guard = create_namespace().unwrap();
+    let _ping_guard = start_ping().unwrap();
+    let trace_guard = start_trace_pipe().unwrap();
+    let _bpfd_guard = start_bpfd().unwrap();
+
+    assert!(iface_exists(DEFAULT_BPFD_IFACE));
+
+    let mut uuids = vec![];
+
+    debug!("Installing 1st tc ingress program");
+    let uuid = add_tc_pass(
+        "ingress",
+        DEFAULT_BPFD_IFACE,
+        75,
+        Some([GLOBAL_1, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        None,
+    )
+    .unwrap();
+    uuids.push(uuid);
+
+    debug!("Installing 1st tc egress program");
+    let uuid = add_tc_pass(
+        "egress",
+        DEFAULT_BPFD_IFACE,
+        75,
+        Some([GLOBAL_4, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        None,
+    )
+    .unwrap();
+    uuids.push(uuid);
+
+    debug!("wait for some traffic to generate logs...");
+    sleep(Duration::from_secs(2));
+
+    let ping_log = read_ping_log().unwrap();
+    // Make sure we've had some pings
+    assert!(ping_log.lines().count() > 2);
+
+    // Make sure the first programs are running and logging
+    let trace_pipe_log = read_trace_pipe_log().unwrap();
+    assert!(!trace_pipe_log.is_empty());
+    assert!(trace_pipe_log.contains(TC_ING_GLOBAL_1_LOG));
+    assert!(trace_pipe_log.contains(TC_EG_GLOBAL_4_LOG));
+
+    // Install a 2nd tc program in each direction with a higher priority that
+    // doesn't proceed on "ok", which this program will return.  We should see
+    // logs from the 2nd programs, but still not the first.
+    debug!("Installing 2nd tc ingress program");
+    let uuid = add_tc_pass(
+        "ingress",
+        DEFAULT_BPFD_IFACE,
+        50,
+        Some([GLOBAL_2, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        Some(["shot", "dispatcher_return"].to_vec()),
+    )
+    .unwrap();
+    uuids.push(uuid);
+
+    debug!("Installing 2nd tc egress program");
+    let uuid = add_tc_pass(
+        "egress",
+        DEFAULT_BPFD_IFACE,
+        50,
+        Some([GLOBAL_5, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        Some(["shot", "dispatcher_return"].to_vec()),
+    )
+    .unwrap();
+    uuids.push(uuid);
+
+    debug!("Clear the trace_pipe_log");
+    drop(trace_guard);
+    let trace_guard = start_trace_pipe().unwrap();
+
+    debug!("wait for some traffic to generate logs...");
+    sleep(Duration::from_secs(2));
+
+    // Make sure we have logs from the 2nd programs, but not from the 1st
+    // programs.
+    let trace_pipe_log = read_trace_pipe_log().unwrap();
+    assert!(!trace_pipe_log.is_empty());
+    assert!(!trace_pipe_log.contains(TC_ING_GLOBAL_1_LOG));
+    assert!(trace_pipe_log.contains(TC_ING_GLOBAL_2_LOG));
+    assert!(!trace_pipe_log.contains(TC_EG_GLOBAL_4_LOG));
+    assert!(trace_pipe_log.contains(TC_EG_GLOBAL_5_LOG));
+
+    // Install a 3rd tc program in each direction with a higher priority that
+    // proceeds on "ok", which this program will return.  We should see logs
+    // from the 2nd and 3rd programs, but still not the first.
+    debug!("Installing 3rd tc ingress program");
+    let uuid = add_tc_pass(
+        "ingress",
+        DEFAULT_BPFD_IFACE,
+        50,
+        Some([GLOBAL_3, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        Some(["ok", "dispatcher_return"].to_vec()),
+    )
+    .unwrap();
+    uuids.push(uuid);
+
+    debug!("Installing 3rd tc egress program");
+    let uuid = add_tc_pass(
+        "egress",
+        DEFAULT_BPFD_IFACE,
+        50,
+        Some([GLOBAL_6, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        Some(["ok", "dispatcher_return"].to_vec()),
+    )
+    .unwrap();
+    uuids.push(uuid);
+
+    debug!("Clear the trace_pipe_log");
+    drop(trace_guard);
+    let _trace_guard = start_trace_pipe().unwrap();
+
+    debug!("wait for some traffic to generate logs...");
+    sleep(Duration::from_secs(2));
+
+    // Make sure we have logs from the 2nd and 3rd TC programs, but not from the
+    // 1st programs.
+    let trace_pipe_log = read_trace_pipe_log().unwrap();
+    assert!(!trace_pipe_log.is_empty());
+    assert!(!trace_pipe_log.contains(TC_ING_GLOBAL_1_LOG));
+    assert!(trace_pipe_log.contains(TC_ING_GLOBAL_2_LOG));
+    assert!(trace_pipe_log.contains(TC_ING_GLOBAL_3_LOG));
+    debug!("Successfully completed tc ingress proceed-on test");
+    assert!(!trace_pipe_log.contains(TC_EG_GLOBAL_4_LOG));
+    assert!(trace_pipe_log.contains(TC_EG_GLOBAL_5_LOG));
+    assert!(trace_pipe_log.contains(TC_EG_GLOBAL_6_LOG));
+    debug!("Successfully completed tc egress proceed-on test");
+
+    // Delete the installed programs
+    debug!("Deleting bpfd programs");
+    for id in uuids.iter() {
+        bpfd_del_program(id)
+    }
+
+    // Verify bpfctl list does not contain the uuids of the deleted programs
+    // and that there are no panics if bpfctl does not contain any programs.
+    let bpfctl_list = bpfd_list().unwrap();
+    for id in uuids.iter() {
+        assert!(!bpfctl_list.contains(id));
+    }
+}
+
+#[integration_test]
+fn test_program_execution_with_global_variables() {
+    let _namespace_guard = create_namespace().unwrap();
+    let _ping_guard = start_ping().unwrap();
+    let _trace_guard = start_trace_pipe().unwrap();
+    let _bpfd_guard = start_bpfd().unwrap();
+
+    assert!(iface_exists(DEFAULT_BPFD_IFACE));
+
+    let mut uuids = vec![];
+
+    debug!("Installing xdp program");
+    let uuid = add_xdp_pass(
+        DEFAULT_BPFD_IFACE,
+        75,
+        Some([GLOBAL_1, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        None,
+    )
+    .unwrap();
+
+    // Verify bpfctl list contains the uuid
+    let bpfctl_list = bpfd_list().unwrap();
+    assert!(bpfctl_list.contains(&uuid));
+
+    uuids.push(uuid);
+
+    // Verify the bppfs has entries
+    assert!(PathBuf::from(RTDIR_FS_XDP)
+        .read_dir()
+        .unwrap()
+        .next()
+        .is_some());
+
+    debug!("Installing tc ingress program");
+    let uuid = add_tc_pass(
+        "ingress",
+        DEFAULT_BPFD_IFACE,
+        50,
+        Some([GLOBAL_1, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        None,
+    )
+    .unwrap();
+
+    // Verify bpfctl list contains the uuid
+    let bpfctl_list = bpfd_list().unwrap();
+    assert!(bpfctl_list.contains(&uuid));
+
+    uuids.push(uuid);
+
+    // Verify the bppfs has entries
+    assert!(PathBuf::from(RTDIR_FS_TC_INGRESS)
+        .read_dir()
+        .unwrap()
+        .next()
+        .is_some());
+
+    debug!("Installing tc egress program");
+    let uuid = add_tc_pass(
+        "egress",
+        DEFAULT_BPFD_IFACE,
+        50,
+        Some([GLOBAL_4, "GLOBAL_u32=0A0B0C0D"].to_vec()),
+        None,
+    )
+    .unwrap();
+
+    // Verify bpfctl list contains the uuid
+    let bpfctl_list = bpfd_list().unwrap();
+    assert!(bpfctl_list.contains(&uuid));
+
+    uuids.push(uuid);
+
+    // Verify the bppfs has entries
+    assert!(PathBuf::from(RTDIR_FS_TC_EGRESS)
+        .read_dir()
+        .unwrap()
+        .next()
+        .is_some());
+
+    debug!("Installing tracepoint program");
+    let uuid = add_tracepoint(Some([GLOBAL_1, "GLOBAL_u32=0A0B0C0D"].to_vec())).unwrap();
+
+    // Verify bpfctl list contains the uuid
+    let bpfctl_list = bpfd_list().unwrap();
+    assert!(bpfctl_list.contains(&uuid));
+
+    uuids.push(uuid);
+
+    debug!("wait for some traffic to generate logs...");
+    sleep(Duration::from_secs(2));
+
+    let ping_log = read_ping_log().unwrap();
+    // Make sure we've had some pings
+    assert!(ping_log.lines().count() > 2);
+
+    let trace_pipe_log = read_trace_pipe_log().unwrap();
+    assert!(!trace_pipe_log.is_empty());
+    assert!(trace_pipe_log.contains(XDP_GLOBAL_1_LOG));
+    debug!("Successfully validated xdp global variable");
+    assert!(trace_pipe_log.contains(TC_ING_GLOBAL_1_LOG));
+    debug!("Successfully validated tc ingress global variable");
+    assert!(trace_pipe_log.contains(TC_EG_GLOBAL_4_LOG));
+    debug!("Successfully validated tc egress global variable");
+    assert!(trace_pipe_log.contains(TRACEPOINT_GLOBAL_1_LOG));
+    debug!("Successfully validated tracepoint global variable");
+
+    // Delete the installed programs
+    debug!("Deleting bpfd programs");
+    for id in uuids.iter() {
+        bpfd_del_program(id)
+    }
+
+    // Verify bpfctl list does not contain the uuids of the deleted programs
+    // and that there are no panics if bpfctl does not contain any programs.
+    let bpfctl_list = bpfd_list().unwrap();
+    for id in uuids.iter() {
+        assert!(!bpfctl_list.contains(id));
+    }
+
+    // Verify the bppfs is empty
+    assert!(PathBuf::from(RTDIR_FS_XDP)
+        .read_dir()
+        .unwrap()
+        .next()
+        .is_none());
+    assert!(PathBuf::from(RTDIR_FS_TC_INGRESS)
+        .read_dir()
+        .unwrap()
+        .next()
+        .is_none());
+    assert!(PathBuf::from(RTDIR_FS_TC_EGRESS)
+        .read_dir()
+        .unwrap()
+        .next()
+        .is_none());
+}

--- a/tests/integration-test/src/tests/mod.rs
+++ b/tests/integration-test/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod basic;
+pub mod e2e;
 pub mod utils;
 
 pub use integration_test_macros::integration_test;

--- a/tests/integration-test/src/tests/utils.rs
+++ b/tests/integration-test/src/tests/utils.rs
@@ -1,16 +1,32 @@
-use std::{process::Command, thread::sleep, time::Duration};
+use std::{fs::File, io::Read, process::Command, thread::sleep, time::Duration};
 
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use log::debug;
 use predicates::str::is_empty;
 
-const DEFAULT_BPFD_IFACE: &str = "eth0";
+const NS_NAME: &str = "bpfd-int-test";
+
+const HOST_VETH: &str = "veth-bpfd-host";
+const NS_VETH: &str = "veth-bpfd-ns";
+
+// The default prefix can be overriden by setting the BPFD_IP_PREFIX environment variable
+const DEFAULT_IP_PREFIX: &str = "172.37.37";
+const IP_MASK: &str = "24";
+const HOST_IP_ID: &str = "1";
+const NS_IP_ID: &str = "2";
+
+pub const DEFAULT_BPFD_IFACE: &str = HOST_VETH;
+
+const PING_FILE_NAME: &str = "/tmp/bpfd_ping.log";
+const TRACE_PIPE_FILE_NAME: &str = "/tmp/bpfd_trace_pipe.log";
+
 const XDP_PASS_IMAGE_LOC: &str = "quay.io/bpfd-bytecode/xdp_pass:latest";
 const TC_PASS_IMAGE_LOC: &str = "quay.io/bpfd-bytecode/tc_pass:latest";
 const TRACEPOINT_IMAGE_LOC: &str = "quay.io/bpfd-bytecode/tracepoint:latest";
 
 /// Exit on panic as well as the passing of a test
+#[derive(Debug)]
 pub struct ChildGuard {
     name: &'static str,
     child: std::process::Child,
@@ -18,6 +34,7 @@ pub struct ChildGuard {
 
 impl Drop for ChildGuard {
     fn drop(&mut self) {
+        debug!("stopping {}", self.name);
         if let Err(e) = self.child.kill() {
             println!("Could not kill {}: {e}", self.name);
         }
@@ -34,42 +51,59 @@ pub fn start_bpfd() -> Result<ChildGuard> {
         name: "bpfd",
         child: c,
     })?;
-    sleep(Duration::from_secs(2));
+
+    // Wait for up to 5 seconds for bpfd to be ready
+    sleep(Duration::from_millis(100));
+    for i in 1..51 {
+        if let Err(e) = Command::cargo_bin("bpfctl")?.args(["list"]).ok() {
+            if i == 50 {
+                panic!("bpfd not ready after {} ms. Error:\n{}", i * 100, e);
+            } else {
+                sleep(Duration::from_millis(100));
+            }
+        } else {
+            break;
+        }
+    }
     debug!("Successfully Started bpfd");
+
     Ok(bpfd_process)
 }
 
-/// Check for a specified bpfd interface environmental, otherwise set a default
-pub fn read_iface_env() -> &'static str {
-    option_env!("BPFD_IFACE").unwrap_or(DEFAULT_BPFD_IFACE)
-}
-
 /// Install an xdp_pass program with bpfctl
-pub fn add_xdp_pass(iface: &str, priority: u32) -> Result<String> {
-    let output = Command::cargo_bin("bpfctl")?
-        .args([
-            "load-from-image",
-            "--global",
-            "GLOBAL_u8=25",
-            "GLOBAL_u32=0A0B0C0D",
-            "--image-url",
-            XDP_PASS_IMAGE_LOC,
-            "--pull-policy",
-            "Always",
-            "xdp",
-            "--iface",
-            iface,
-            "--priority",
-            priority.to_string().as_str(),
-            "--proceed-on",
-            "aborted",
-            "drop",
-            "pass",
-            "tx",
-            "redirect",
-            "dispatcher_return",
-        ])
-        .ok();
+pub fn add_xdp_pass(
+    iface: &str,
+    priority: u32,
+    globals: Option<Vec<&str>>,
+    proceed_on: Option<Vec<&str>>,
+) -> Result<String> {
+    let p = priority.to_string();
+
+    let mut args = vec!["load-from-image"];
+
+    if let Some(g) = globals {
+        args.extend(["--global"]);
+        args.extend(g);
+    }
+
+    args.extend([
+        "--image-url",
+        XDP_PASS_IMAGE_LOC,
+        "--pull-policy",
+        "Always",
+        "xdp",
+        "--iface",
+        iface,
+        "--priority",
+        p.as_str(),
+    ]);
+
+    if let Some(p_o) = proceed_on {
+        args.extend(["--proceed-on"]);
+        args.extend(p_o);
+    }
+
+    let output = Command::cargo_bin("bpfctl")?.args(args).ok();
     let stdout = String::from_utf8(output.unwrap().stdout).unwrap();
     let uuid = stdout.trim();
     assert!(!uuid.is_empty());
@@ -79,62 +113,69 @@ pub fn add_xdp_pass(iface: &str, priority: u32) -> Result<String> {
 }
 
 /// Install a tc_pass program with bpfctl
-pub fn add_tc_pass(iface: &str, priority: u32) -> Result<String> {
-    let output = Command::cargo_bin("bpfctl")?
-        .args([
-            "load-from-image",
-            "--global",
-            "GLOBAL_u8=25",
-            "GLOBAL_u32=0A0B0C0D",
-            "--image-url",
-            TC_PASS_IMAGE_LOC,
-            "--pull-policy",
-            "Always",
-            "tc",
-            "--direction",
-            "ingress",
-            "--iface",
-            iface,
-            "--priority",
-            priority.to_string().as_str(),
-            "--proceed-on",
-            "unspec",
-            "ok",
-            "reclassify",
-            "shot",
-            "pipe",
-            "stolen",
-            "queued",
-            "repeat",
-            "redirect",
-            "trap",
-            "dispatcher_return",
-        ])
-        .ok();
+pub fn add_tc_pass(
+    direction: &str,
+    iface: &str,
+    priority: u32,
+    globals: Option<Vec<&str>>,
+    proceed_on: Option<Vec<&str>>,
+) -> Result<String> {
+    let p = priority.to_string();
+
+    let mut args = vec!["load-from-image"];
+
+    if let Some(g) = globals {
+        args.extend(["--global"]);
+        args.extend(g);
+    }
+
+    args.extend([
+        "--image-url",
+        TC_PASS_IMAGE_LOC,
+        "--pull-policy",
+        "Always",
+        "tc",
+        "--direction",
+        direction,
+        "--iface",
+        iface,
+        "--priority",
+        p.as_str(),
+    ]);
+
+    if let Some(p_o) = proceed_on {
+        args.extend(["--proceed-on"]);
+        args.extend(p_o);
+    }
+
+    let output = Command::cargo_bin("bpfctl")?.args(args).ok();
     let stdout = String::from_utf8(output.unwrap().stdout).unwrap();
     let uuid = stdout.trim();
     assert!(!uuid.is_empty());
-    debug!("Successfully added tc_pass program: {:?}", uuid);
+    debug!("Successfully added tc {} program: {:?}", direction, uuid);
     Ok(uuid.to_string())
 }
 
-/// Install an tracepoint program with bpfctl
-pub fn add_tracepoint() -> Result<String> {
-    let output = Command::cargo_bin("bpfctl")?
-        .args([
-            "load-from-image",
-            "--global",
-            "GLOBAL_u8=25",
-            "GLOBAL_u32=0A0B0C0D",
-            "--image-url",
-            TRACEPOINT_IMAGE_LOC,
-            "--pull-policy",
-            "Always",
-            "tracepoint",
-            "--tracepoint",
-            "syscalls/sys_enter_openat",
-        ])
-        .ok();
+/// Install a tracepoint program with bpfctl
+pub fn add_tracepoint(globals: Option<Vec<&str>>) -> Result<String> {
+    let mut args = vec!["load-from-image"];
+
+    if let Some(g) = globals {
+        args.extend(["--global"]);
+        args.extend(g);
+    }
+
+    args.extend([
+        "--image-url",
+        TRACEPOINT_IMAGE_LOC,
+        "--pull-policy",
+        "Always",
+        "tracepoint",
+        "--tracepoint",
+        "syscalls/sys_enter_openat",
+    ]);
+
+    let output = Command::cargo_bin("bpfctl")?.args(args).ok();
     let stdout = String::from_utf8(output.unwrap().stdout).unwrap();
     let uuid = stdout.trim();
     assert!(!uuid.is_empty());
@@ -186,4 +227,242 @@ pub fn iface_exists(bpfd_iface: &str) -> bool {
     }
 
     false
+}
+
+pub struct NamespaceGuard {
+    name: &'static str,
+}
+
+/// Delete namespace.  This causes the associated veth's and ip's to also get
+/// deleted
+fn delete_namespace(name: &'static str) {
+    let status = Command::new("ip")
+        .args(["netns", "delete", name])
+        .status()
+        .expect("could not delete namespace");
+
+    if !status.success() {
+        println!("could not delete namespace {name}: {status}");
+    } else {
+        debug!("namespace {} deleted", name);
+    }
+}
+
+impl Drop for NamespaceGuard {
+    fn drop(&mut self) {
+        delete_namespace(self.name);
+    }
+}
+
+fn get_ip_prefix() -> String {
+    match option_env!("BPFD_IP_PREFIX") {
+        Some(ip_prefix) => ip_prefix.to_string(),
+        None => DEFAULT_IP_PREFIX.to_string(),
+    }
+}
+
+fn get_ip_addr(id: &str) -> String {
+    format!("{}.{}", get_ip_prefix(), id)
+}
+
+fn ip_prefix_exists(prefix: &String) -> bool {
+    // It sometimes takes the previous delete_namespace(NS_NAME) a little time to clean
+    // everything up, so give it a little time before checking.
+    sleep(Duration::from_millis(100));
+
+    let output = Command::new("ip")
+        .args(["address", "list"])
+        .output()
+        .expect("Failed to create namespace");
+
+    if !output.status.success() {
+        panic!("could not execute \"ip address list\" command");
+    };
+
+    let stdout = String::from_utf8(output.unwrap().stdout).unwrap();
+    stdout.contains(prefix)
+}
+
+/// Create a namespace [`NS_NAME`] with a veth pair and IP addresses
+pub fn create_namespace() -> Result<NamespaceGuard> {
+    if ip_prefix_exists(&get_ip_prefix()) {
+        panic!(
+            "ip prefix {} is in use, specify an available prefix with env BPFD_IP_PREFIX.",
+            get_ip_prefix()
+        );
+    }
+
+    let status = Command::new("ip")
+        .args(["netns", "add", NS_NAME])
+        .status()
+        .expect("Failed to create namespace");
+
+    if !status.success() {
+        panic!("failed to create namespace {NS_NAME}: {status}");
+    }
+
+    let status = Command::new("ip")
+        .args([
+            "link", "add", HOST_VETH, "type", "veth", "peer", "name", NS_VETH,
+        ])
+        .status()
+        .expect("Failed to create namespace");
+
+    if !status.success() {
+        delete_namespace(NS_NAME);
+        panic!("failed to create veth pair {HOST_VETH}-{NS_VETH}: {status}");
+    }
+
+    let status = Command::new("ip")
+        .args(["link", "set", NS_VETH, "netns", NS_NAME])
+        .status()
+        .expect("Failed to create namespace");
+
+    if !status.success() {
+        delete_namespace(NS_NAME);
+        panic!("failed to add veth {NS_VETH} to {NS_NAME}: {status}");
+    }
+
+    let ns_ip_mask = format!("{}/{}", get_ip_addr(NS_IP_ID), IP_MASK);
+
+    let status = Command::new("ip")
+        .args([
+            "netns",
+            "exec",
+            NS_NAME,
+            "ip",
+            "addr",
+            "add",
+            &ns_ip_mask,
+            "dev",
+            NS_VETH,
+        ])
+        .status()
+        .expect("Failed to create namespace");
+
+    if !status.success() {
+        delete_namespace(NS_NAME);
+        panic!(
+            "failed to add ip address {ns_ip_mask} to {NS_VETH}: {status}\n
+        if {ns_ip_mask} is not available, specify a usable prefix with env BPFD_IT_PREFIX.\n 
+        for example: export BPFD_IT_PREFIX=\"192.168.1\""
+        );
+    }
+
+    let host_ip_mask = format!("{}/{}", get_ip_addr(HOST_IP_ID), IP_MASK);
+
+    let status = Command::new("ip")
+        .args(["addr", "add", &host_ip_mask, "dev", HOST_VETH])
+        .status()
+        .expect("Failed to create namespace");
+
+    if !status.success() {
+        delete_namespace(NS_NAME);
+        panic!("failed to add ip address {ns_ip_mask} to {HOST_VETH}: {status}");
+    }
+
+    let status = Command::new("ip")
+        .args([
+            "netns", "exec", NS_NAME, "ip", "link", "set", "dev", NS_VETH, "up",
+        ])
+        .status()
+        .expect("Failed to create namespace");
+
+    if !status.success() {
+        delete_namespace(NS_NAME);
+        panic!("failed to set dev {NS_VETH} to up: {status}");
+    }
+
+    let status = Command::new("ip")
+        .args(["link", "set", "dev", HOST_VETH, "up"])
+        .status()
+        .expect("Failed to create namespace");
+
+    if !status.success() {
+        delete_namespace(NS_NAME);
+        panic!("failed to set dev {HOST_VETH} to up: {status}");
+    }
+
+    debug!("Successfully created namespace {NS_NAME}");
+
+    Ok(NamespaceGuard { name: NS_NAME })
+}
+
+/// start a ping to the network namespace IP address with output logged to [`PING_FILE_NAME`]
+pub fn start_ping() -> Result<ChildGuard> {
+    let f = File::create(PING_FILE_NAME).unwrap();
+    let ping_process = Command::new("ping")
+        .args([get_ip_addr(NS_IP_ID)])
+        .stdout(std::process::Stdio::from(f))
+        .spawn()
+        .map(|c| ChildGuard {
+            name: "ping",
+            child: c,
+        })
+        .expect("Failed to start ping");
+
+    debug!(
+        "sucessfully started ping to namespace {} at address {}",
+        NS_NAME,
+        get_ip_addr(NS_IP_ID),
+    );
+
+    Ok(ping_process)
+}
+
+/// Get the ping log from [`PING_FILE_NAME`]
+pub fn read_ping_log() -> Result<String> {
+    let mut f = File::open(PING_FILE_NAME)?;
+    let mut buffer = String::new();
+    f.read_to_string(&mut buffer)?;
+    Ok(buffer)
+}
+
+/// start sending /sys/kernel/debug/tracing/trace_pipe to [`TRACE_PIPE_FILE_NAME`]
+pub fn start_trace_pipe() -> Result<ChildGuard> {
+    // The trace_pipe is clear on read, so we start a process to read it to
+    // clear any logs left over from the last test.  Kill that process and then
+    // start the real one.
+
+    // Start it
+    let f = File::create(TRACE_PIPE_FILE_NAME).unwrap();
+    let mut trace_process = Command::new("cat")
+        .args(["/sys/kernel/debug/tracing/trace_pipe"])
+        .stdout(std::process::Stdio::from(f))
+        .spawn()
+        .expect("Failed to start trace_pipe");
+
+    sleep(Duration::from_secs(1));
+
+    // Kill it
+    if let Err(e) = trace_process.kill() {
+        println!("Could not kill trace_pipe: {e}");
+    }
+    if let Err(e) = trace_process.wait() {
+        println!("Could not wait for trace_pipe: {e}");
+    }
+
+    // Start it again
+    let f = File::create(TRACE_PIPE_FILE_NAME).unwrap();
+    let trace_process = Command::new("cat")
+        .args(["/sys/kernel/debug/tracing/trace_pipe"])
+        .stdout(std::process::Stdio::from(f))
+        .spawn()
+        .map(|c| ChildGuard {
+            name: "trace_pipe",
+            child: c,
+        })
+        .expect("Failed to start trace_pipe");
+
+    debug!("sucessfully started cat trace_pipe",);
+    Ok(trace_process)
+}
+
+/// get the trace_pipe output from [`TRACE_PIPE_FILE_NAME`]
+pub fn read_trace_pipe_log() -> Result<String> {
+    let mut f = File::open(TRACE_PIPE_FILE_NAME)?;
+    let mut buffer = String::new();
+    f.read_to_string(&mut buffer)?;
+    debug!("trace_pipe output read to string");
+    Ok(buffer)
 }


### PR DESCRIPTION
The existing integration tests validate the basic loading, unloading, and cli functionality for bpfd.  However, they do not validate that the programs are actually running or that any of the advanced features actually work.  This commit adds support for these functions to include the following.

eBPF Integration Test Framework:
- Create and use a network namespace with a veth pair and IP addresses for testing XDP and TC programs
- Start, capture, and retrieve the output of pings to the network namespace to generate traffic for these programs
- Capture and retrieve `/sys/kernel/debug/tracing/trace_pipe` so that `bpf_printk()` logs from eBPF programs can be examined

The above provides a framework with which functionality can be easily tested by adding and examining `bpf_printk()` output to/from the eBPF programs being installed to confirm that they are working correctly.  Using the namespace has the added benefit that we can add XDP and TC programs to the veth that we created and not bother the user with having to configure an interface to use.

Additionally, tests have been added for the following functionality using this framework:
- the programs loaded are actually running
- setting of global variables
- priority for XDP and TC programs
- proceed-on for XDP and TC programs
- tests for TC egress in addition to ingress

I also made the change from `bpfctl --help` to `bpfctl list` in `build.yml`.

Fixes: #394
