### PR TITLE
temp fix for ubuntu-latest mirror issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
           if-no-files-found: error
 
   basic-integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: ["build", "build-go"]
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -39,7 +39,7 @@ jobs:
         toolchain: stable
         override: true
     - name: Install libelf-dev
-      run: sudo apt-get install -y linux-headers-generic clang lldb lld libelf-dev gcc-multilib
+      run: sudo apt-get install -y linux-headers-`uname -r` clang lldb lld libelf-dev gcc-multilib
 
     - name: Login to quay.io/bpfd
       uses: redhat-actions/podman-login@v1


### PR DESCRIPTION
Temporally fix out CI by reverting the ubuntu base image.

Tracked in https://github.com/bpfd-dev/bpfd/issues/517