### PR TITLE
Example build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,6 +231,9 @@ jobs:
       - name: build images
         run: cd bpfd-operator && make build-images
 
+      - name: build example images
+        run: cd examples && make build-us-images
+
       - name: run integration tests
         run: cd bpfd-operator && make test-integration
 

--- a/docs/getting-started/example-bpf-k8s.md
+++ b/docs/getting-started/example-bpf-k8s.md
@@ -373,6 +373,9 @@ To see the full set of available commands, run `make help`:
     Build
       build            Build all the userspace example code.
       generate         Run `go generate` to build the bytecode for each of the examples.
+      build-us-images  Build all example userspace images
+      push-us-images   Push all example userspace images
+      load-us-images-kind  Build and load all example userspace images into kind
 
     Deployment Variables (not commands)
       TAG              Used to set all images to a fixed tag. Example: make deploy TAG=v0.2.0
@@ -382,6 +385,7 @@ To see the full set of available commands, run `make help`:
       IMAGE_TP_US      Tracepoint Userspace image. Example: make deploy-tracepoint IMAGE_TP_US=quay.io/user1/go-tracepoint-counter-userspace:test
       IMAGE_XDP_BC     XDP Bytecode image. Example: make deploy-xdp IMAGE_XDP_BC=quay.io/user1/go-xdp-counter-bytecode:test
       IMAGE_XDP_US     XDP Userspace image. Example: make deploy-xdp IMAGE_XDP_US=quay.io/user1/go-xdp-counter-userspace:test
+      KIND_CLUSTER_NAME  Name of the deployed cluster to load example images to, defaults to `bpfd-deployment`
       ignore-not-found  For any undeploy command, set to true to ignore resource not found errors during deletion. Example: make undeploy ignore-not-found=true
 
     Deployment
@@ -389,7 +393,7 @@ To see the full set of available commands, run `make help`:
       undeploy-tc      Undeploy go-tc-counter from the cluster specified in ~/.kube/config.
       deploy-tracepoint  Deploy go-tracepoint-counter to the cluster specified in ~/.kube/config.
       undeploy-tracepoint  Undeploy go-tracepoint-counter from the cluster specified in ~/.kube/config.
-      deploy-xdp       Deploy go-xdp-counter to the cluster specified in ~/.kube/config.ifdef TAG
+      deploy-xdp       Deploy go-xdp-counter to the cluster specified in ~/.kube/config.
       undeploy-xdp     Undeploy go-xdp-counter from the cluster specified in ~/.kube/config.
       deploy           Deploy all examples to the cluster specified in ~/.kube/config.
       undeploy         Undeploy all examples to the cluster specified in ~/.kube/config.
@@ -398,25 +402,40 @@ To see the full set of available commands, run `make help`:
 #### Building A Userspace Container Image
 
 To build the userspace examples in a container instead of using the pre-built ones,
-from the bpfd code source directory, run the following build commands:
+from the bpfd code source directory (`quay.io/bpfd-userspace/`), run the following build commands:
 
 ```console
-    cd bpfd/
-    docker build -f examples/go-xdp-counter/container-deployment/Containerfile.go-xdp-counter . -t quay.io/$USER/go-xdp-counter:latest
-    docker build -f examples/go-tc-counter/container-deployment/Containerfile.go-tc-counter . -t quay.io/$USER/go-tc-counter:latest
-    docker build -f examples/go-tracepoint-counter/container-deployment/Containerfile.go-tracepoint-counter . -t quay.io/$USER/go-tracepoint-counter:latest
+    cd bpfd/examples
+    make IMAGE_TC_US=quay.io/$USER/go-tc-counter:latest \
+    IMAGE_TP_US=quay.io/$USER/go-tracepoint-counter:latest \
+    IMAGE_XDP_US=quay.io/$USER/go-xdp-counter:latest \
+    build-us-images
 ```
 
-Then push images to a remote repository:
+Then **EITHER** push images to a remote repository:
 
 ```console
     docker login quay.io
-    docker push quay.io/$USER/go-xdp-counter:latest
-    docker push quay.io/$USER/go-tc-counter:latest
-    docker push quay.io/$USER/go-tracepoint-counter:latest
+    cd bpfd/examples
+    make IMAGE_TC_US=quay.io/$USER/go-tc-counter:latest \
+    IMAGE_TP_US=quay.io/$USER/go-tracepoint-counter:latest \
+    IMAGE_XDP_US=quay.io/$USER/go-xdp-counter:latest \
+
+    push-us-images
 ```
 
-Update the yaml to use the private images or override the yaml files using the Makefile:
+**OR** load the images directly to a specified kind cluster:
+
+```console
+    cd bpfd/examples
+    make IMAGE_TC_US=quay.io/$USER/go-tc-counter:latest \
+    IMAGE_TP_US=quay.io/$USER/go-tracepoint-counter:latest \
+    IMAGE_XDP_US=quay.io/$USER/go-xdp-counter:latest \
+    KIND_CLUSTER_NAME=bpfd-deployment \
+    load-us-images-kind
+```
+
+Lastly, update the yaml to use the private images or override the yaml files using the Makefile:
 
 ```console
     cd bpfd/examples/

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -104,6 +104,22 @@ build: fmt ## Build all the userspace example code.
 generate: ## Run `go generate` to build the bytecode for each of the examples.
 	go generate ./...
 
+.PHONY: build-us-images
+build-us-images: ## Build all example userspace images
+	docker build -t ${IMAGE_TC_US} -f ./go-tc-counter/container-deployment/Containerfile.go-tc-counter ../
+	docker build -t ${IMAGE_TP_US} -f ./go-tracepoint-counter/container-deployment/Containerfile.go-tracepoint-counter ../
+	docker build -t ${IMAGE_XDP_US} -f ./go-xdp-counter/container-deployment/Containerfile.go-xdp-counter ../
+
+.PHONY: push-us-images
+push-us-images: ## Push all example userspace images
+	docker push ${IMAGE_TC_US}
+	docker push ${IMAGE_TP_US}
+	docker pus ${IMAGE_XDP_US}
+
+.PHONY: load-us-images-kind
+load-us-images-kind: build-us-images ## Build and load all example userspace images into kind
+	kind load docker-image ${IMAGE_TC_US} ${IMAGE_TP_US} ${IMAGE_XDP_US} --name ${KIND_CLUSTER_NAME}
+
 ##@ Deployment Variables (not commands)
 TAG: ## Used to set all images to a fixed tag. Example: make deploy TAG=v0.2.0
 IMAGE_TC_BC: ## TC Bytecode image. Example: make deploy-tc IMAGE_TC_BC=quay.io/user1/go-tc-counter-bytecode:test
@@ -112,6 +128,7 @@ IMAGE_TP_BC: ## Tracepoint Bytecode image. Example: make deploy-tracepoint IMAGE
 IMAGE_TP_US: ## Tracepoint Userspace image. Example: make deploy-tracepoint IMAGE_TP_US=quay.io/user1/go-tracepoint-counter-userspace:test
 IMAGE_XDP_BC: ## XDP Bytecode image. Example: make deploy-xdp IMAGE_XDP_BC=quay.io/user1/go-xdp-counter-bytecode:test
 IMAGE_XDP_US: ## XDP Userspace image. Example: make deploy-xdp IMAGE_XDP_US=quay.io/user1/go-xdp-counter-userspace:test
+KIND_CLUSTER_NAME: ## Name of the deployed cluster to load example images to, defaults to `bpfd-deployment`
 ignore-not-found: ## For any undeploy command, set to true to ignore resource not found errors during deletion. Example: make undeploy ignore-not-found=true
 
 ##@ Deployment
@@ -122,6 +139,7 @@ IMAGE_TP_US ?= quay.io/bpfd-userspace/go-tracepoint-counter:latest
 IMAGE_XDP_BC ?= quay.io/bpfd-bytecode/go-xdp-counter:latest
 IMAGE_XDP_US ?= quay.io/bpfd-userspace/go-xdp-counter:latest
 KUST_DIR=default
+KIND_CLUSTER_NAME ?= bpfd-deployment
 
 .PHONY: deploy-tc
 deploy-tc: kustomize ## Deploy go-tc-counter to the cluster specified in ~/.kube/config.

--- a/examples/config/base/go-tc-counter/deployment.yaml
+++ b/examples/config/base/go-tc-counter/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       containers:
       - name: go-tc-counter
         image: quay.io/bpfd-userspace/go-tc-counter:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         env:

--- a/examples/config/base/go-tracepoint-counter/deployment.yaml
+++ b/examples/config/base/go-tracepoint-counter/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       containers:
       - name: go-tracepoint-counter
         image: quay.io/bpfd-userspace/go-tracepoint-counter:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         env:

--- a/examples/config/base/go-xdp-counter/deployment.yaml
+++ b/examples/config/base/go-xdp-counter/deployment.yaml
@@ -74,7 +74,7 @@ spec:
       containers:
       - name: go-xdp-counter
         image: quay.io/bpfd-userspace/go-xdp-counter:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
Add targets to the examples makefile to build all the user space images and to easily load them into kind.

Also update our Kubernetes integration tests to use fresh userspace images in CI.