### PR TITLE
List programs k8s

### DIFF
--- a/bpfd-operator/cmd/bpfd-agent/main.go
+++ b/bpfd-operator/cmd/bpfd-agent/main.go
@@ -161,6 +161,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&bpfdagent.DiscoveredProgramReconciler{
+		ReconcilerCommon: common,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create discoveredProgram controller", "controller", "BpfProgram")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/bpfd-operator/controllers/bpfd-agent/discovered_program.go
+++ b/bpfd-operator/controllers/bpfd-agent/discovered_program.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2023.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bpfdagent
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	bpfdiov1alpha1 "github.com/bpfd-dev/bpfd/bpfd-operator/apis/v1alpha1"
+	bpfdagentinternal "github.com/bpfd-dev/bpfd/bpfd-operator/controllers/bpfd-agent/internal"
+	"github.com/bpfd-dev/bpfd/bpfd-operator/internal"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	syncDurationDiscoveredController = 30 * time.Second
+)
+
+type DiscoveredProgramReconciler struct {
+	ReconcilerCommon
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *DiscoveredProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("DiscoveredProgramController").
+		// Only trigger reconciliation if node object changed. Additionally always
+		// exit the end of a reconcile with a requeue so that the discovered programs
+		// are kept up to date.
+		Watches(
+			&source.Kind{Type: &v1.Node{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicate.And(predicate.ResourceVersionChangedPredicate{}, nodePredicate(r.NodeName))),
+		).
+		Watches(
+			&source.Kind{Type: &bpfdiov1alpha1.BpfProgram{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicate.And(
+				internal.BpfProgramNodePredicate(r.NodeName)),
+				internal.DiscoveredBpfProgramPredicate(),
+			),
+		).
+		Complete(r)
+}
+
+// Reconcile ALL discovered bpf programs on the system whenever an event is received.
+func (r *DiscoveredProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Logger = log.FromContext(ctx)
+
+	// Get existing ebpf state from bpfd.
+	programs, err := bpfdagentinternal.ListAllPrograms(ctx, r.BpfdClient)
+	if err != nil {
+		r.Logger.Error(err, "failed to list loaded bpf programs")
+		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationAgent}, nil
+	}
+
+	for _, p := range programs {
+
+		// skip bpf programs loaded by bpfd, their corresponding bpfProgram object
+		// will be managed by another controller.
+		if p.Id != nil {
+			continue
+		}
+
+		// TODO(astoycos) across the operator we need a better way to validate that
+		// the name we're building is a valid k8's object name i.e meets the
+		// regex: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+		// laid out here -> https://github.com/kubernetes/apimachinery/blob/v0.27.4/pkg/util/validation/validation.go#L43C6-L43C21
+		bpfProgName := ""
+		if len(p.Name) == 0 {
+			bpfProgName = fmt.Sprintf("%d-%s", p.BpfId, r.NodeName)
+		} else {
+			bpfProgName = fmt.Sprintf("%s-%d-%s", strings.ReplaceAll(p.Name, "_", "-"), p.BpfId, r.NodeName)
+		}
+
+		existingBpfProg := &bpfdiov1alpha1.BpfProgram{}
+
+		expectedBpfProg := &bpfdiov1alpha1.BpfProgram{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bpfProgName,
+				Labels: map[string]string{internal.DiscoveredLabel: "",
+					internal.K8sHostLabel: r.NodeName},
+				Annotations: bpfdagentinternal.Build_kernel_info_annotations(p),
+			},
+			Spec: bpfdiov1alpha1.BpfProgramSpec{
+				Type: internal.ProgramType(p.ProgramType).String(),
+			},
+			Status: bpfdiov1alpha1.BpfProgramStatus{Conditions: []metav1.Condition{}},
+		}
+
+		// If the bpfProgram object doesn't exist create it.
+		err = r.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: v1.NamespaceAll}, existingBpfProg)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				r.Logger.V(1).Info("Creating discovered bpfProgram object", "name", expectedBpfProg.Name)
+				err = r.Create(ctx, expectedBpfProg)
+				if err != nil {
+					r.Logger.Error(err, "failed to create bpfProgram object")
+					return ctrl.Result{Requeue: false}, nil
+				}
+
+				return ctrl.Result{Requeue: false}, nil
+			}
+
+			r.Logger.Error(err, "failed to build bpfProgram object")
+			return ctrl.Result{Requeue: false}, nil
+		}
+
+		// If the bpfProgram object does exist but is stale update it.
+		if !reflect.DeepEqual(expectedBpfProg.Annotations, existingBpfProg.Annotations) {
+			if err := r.Update(ctx, expectedBpfProg); err != nil {
+				r.Logger.Error(err, "failed to build bpfProgram object")
+			}
+
+			return ctrl.Result{Requeue: false}, nil
+		}
+
+	}
+
+	// If we've created all of the programs, make sure to exit with a retry
+	// so that we resync on a 30 second interval.
+	return ctrl.Result{Requeue: true, RequeueAfter: syncDurationDiscoveredController}, nil
+}

--- a/bpfd-operator/controllers/bpfd-agent/discovered_program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/discovered_program_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bpfdagent
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	bpfdiov1alpha1 "github.com/bpfd-dev/bpfd/bpfd-operator/apis/v1alpha1"
+	bpfdagentinternal "github.com/bpfd-dev/bpfd/bpfd-operator/controllers/bpfd-agent/internal"
+	agenttestutils "github.com/bpfd-dev/bpfd/bpfd-operator/controllers/bpfd-agent/internal/test-utils"
+	internal "github.com/bpfd-dev/bpfd/bpfd-operator/internal"
+	testutils "github.com/bpfd-dev/bpfd/bpfd-operator/internal/test-utils"
+
+	gobpfd "github.com/bpfd-dev/bpfd/clients/gobpfd/v1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestDiscoveredProgramControllerCreate(t *testing.T) {
+	var (
+		namespace    = "bpfd"
+		fakeNode     = testutils.NewNode("fake-control-plane")
+		ctx          = context.TODO()
+		bpfProgName0 = fmt.Sprintf("%s-%d-%s", "dump-bpf-map", 693, fakeNode.Name)
+		bpfProgName1 = fmt.Sprintf("%s-%d-%s", "dump-bpf-prog", 694, fakeNode.Name)
+		bpfProgName2 = fmt.Sprintf("%d-%s", 93149, fakeNode.Name)
+		bpfProg      = &bpfdiov1alpha1.BpfProgram{}
+		fakeUID      = "ef71d42c-aa21-48e8-a697-82391d801a81"
+		programs     = map[string]*gobpfd.ListResponse_ListResult{
+			"dump_bpf_map": {
+				Name:          "dump_bpf_map",
+				Location:      &gobpfd.ListResponse_ListResult_NoLocation{},
+				ProgramType:   26,
+				AttachInfo:    &gobpfd.ListResponse_ListResult_None{},
+				BpfId:         693,
+				LoadedAt:      "2023-03-02T18:15:06+0000",
+				Tag:           "749172daffada61f",
+				GplCompatible: true,
+				MapIds:        []uint32{45},
+				BtfId:         154,
+				BytesXlated:   264,
+				Jited:         true,
+				BytesJited:    287,
+				BytesMemlock:  4096,
+				VerifiedInsns: 34,
+			},
+			"dump_bpf_prog": {
+				Name:          "dump_bpf_prog",
+				Location:      &gobpfd.ListResponse_ListResult_NoLocation{},
+				ProgramType:   26,
+				AttachInfo:    &gobpfd.ListResponse_ListResult_None{},
+				BpfId:         694,
+				LoadedAt:      "2023-03-02T18:15:06+0000",
+				Tag:           "bc36dd738319ea32",
+				GplCompatible: true,
+				MapIds:        []uint32{45},
+				BtfId:         154,
+				BytesXlated:   528,
+				Jited:         true,
+				BytesJited:    715,
+				BytesMemlock:  4096,
+				VerifiedInsns: 84,
+			},
+			// test program with no name
+			"": {
+				Location:      &gobpfd.ListResponse_ListResult_NoLocation{},
+				ProgramType:   8,
+				AttachInfo:    &gobpfd.ListResponse_ListResult_None{},
+				BpfId:         93149,
+				LoadedAt:      "2023-07-20T19:11:11+0000",
+				Tag:           "6deef7357e7b4530",
+				GplCompatible: true,
+				BytesXlated:   64,
+				Jited:         true,
+				BytesJited:    55,
+				BytesMemlock:  4096,
+				VerifiedInsns: 8,
+			},
+			// skip program loaded by bpfd
+			"bpfd-prog": {
+				Id:            &fakeUID,
+				Location:      &gobpfd.ListResponse_ListResult_NoLocation{},
+				ProgramType:   8,
+				AttachInfo:    &gobpfd.ListResponse_ListResult_None{},
+				BpfId:         93149,
+				LoadedAt:      "2023-07-20T19:11:11+0000",
+				Tag:           "6deef7357e7b4530",
+				GplCompatible: true,
+				BytesXlated:   64,
+				Jited:         true,
+				BytesJited:    55,
+				BytesMemlock:  4096,
+				VerifiedInsns: 8,
+			},
+		}
+	)
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{fakeNode}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(bpfdiov1alpha1.SchemeGroupVersion, &bpfdiov1alpha1.BpfProgram{})
+	s.AddKnownTypes(bpfdiov1alpha1.SchemeGroupVersion, &bpfdiov1alpha1.BpfProgramList{})
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+
+	cli := agenttestutils.NewBpfdClientFakeWithPrograms(programs)
+
+	rc := ReconcilerCommon{
+		Client:       cl,
+		Scheme:       s,
+		BpfdClient:   cli,
+		NodeName:     fakeNode.Name,
+		bpfPrograms:  map[string]bpfdiov1alpha1.BpfProgram{},
+		expectedMaps: map[string]string{},
+	}
+
+	// Set development Logger so we can see all logs in tests.
+	logf.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
+
+	// Create a ReconcileMemcached object with the scheme and fake client.
+	r := &DiscoveredProgramReconciler{ReconcilerCommon: rc}
+
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "fake-control-plane",
+			Namespace: namespace,
+		},
+	}
+
+	// Three reconciles should create three bpf program objects
+	res, err := r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	require.False(t, res.Requeue)
+
+	res, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	require.False(t, res.Requeue)
+
+	res, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	require.False(t, res.Requeue)
+
+	// Check the first discovered BpfProgram Object was created successfully
+	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName0, Namespace: metav1.NamespaceAll}, bpfProg)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, bpfProg)
+	// discovered Label is written
+	require.Contains(t, bpfProg.Labels, internal.DiscoveredLabel)
+	// node Label was correctly set
+	require.Equal(t, bpfProg.Labels[internal.K8sHostLabel], fakeNode.Name)
+	// ensure annotations were correct
+	require.Equal(t, bpfProg.Annotations, bpfdagentinternal.Build_kernel_info_annotations(programs["dump_bpf_map"]))
+
+	// Check the second discovered BpfProgram Object was created successfully
+	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProg)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, bpfProg)
+	// discovered Label is written
+	require.Contains(t, bpfProg.Labels, internal.DiscoveredLabel)
+	// node Label was correctly set
+	require.Equal(t, bpfProg.Labels[internal.K8sHostLabel], fakeNode.Name)
+	// ensure annotations were correct
+	require.Equal(t, bpfProg.Annotations, bpfdagentinternal.Build_kernel_info_annotations(programs["dump_bpf_prog"]))
+
+	// Check the third discovered BpfProgram Object was created successfully
+	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName2, Namespace: metav1.NamespaceAll}, bpfProg)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, bpfProg)
+	// discovered Label is written
+	require.Contains(t, bpfProg.Labels, internal.DiscoveredLabel)
+	// node Label was correctly set
+	require.Equal(t, bpfProg.Labels[internal.K8sHostLabel], fakeNode.Name)
+	// ensure annotations were correct
+	require.Equal(t, bpfProg.Annotations, bpfdagentinternal.Build_kernel_info_annotations(programs[""]))
+
+	// The fourth reconcile will end up exiting with a 30 second reqqueue
+	res, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	// Require requeue
+	require.True(t, res.Requeue)
+}

--- a/bpfd-operator/controllers/bpfd-agent/internal/test-utils/fake_bpfd_client.go
+++ b/bpfd-operator/controllers/bpfd-agent/internal/test-utils/fake_bpfd_client.go
@@ -41,6 +41,15 @@ func NewBpfdClientFake() *BpfdClientFake {
 	}
 }
 
+func NewBpfdClientFakeWithPrograms(programs map[string]*gobpfd.ListResponse_ListResult) *BpfdClientFake {
+	return &BpfdClientFake{
+		LoadRequests:   map[string]*gobpfd.LoadRequest{},
+		UnloadRequests: map[string]*gobpfd.UnloadRequest{},
+		ListRequests:   []*gobpfd.ListRequest{},
+		Programs:       programs,
+	}
+}
+
 func (b *BpfdClientFake) Load(ctx context.Context, in *gobpfd.LoadRequest, opts ...grpc.CallOption) (*gobpfd.LoadResponse, error) {
 	b.LoadRequests[*in.Common.Id] = in
 

--- a/bpfd-operator/controllers/bpfd-operator/configmap.go
+++ b/bpfd-operator/controllers/bpfd-operator/configmap.go
@@ -73,7 +73,7 @@ func (r *BpfdConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 	} else {
-		if updated := controllerutil.AddFinalizer(bpfdConfig, "bpfd.dev.operator/finalizer"); updated {
+		if updated := controllerutil.AddFinalizer(bpfdConfig, internal.BpfdOperatorFinalizer); updated {
 			if err := r.Update(ctx, bpfdConfig); err != nil {
 				r.Logger.Error(err, "failed adding bpfd-operator finalizer to bpfd config")
 				return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
@@ -211,7 +211,7 @@ func LoadAndConfigureBpfdDs(config *corev1.ConfigMap, path string) *appsv1.Daemo
 	staticBpfdDeployment.Namespace = config.Namespace
 	staticBpfdDeployment.Spec.Template.Spec.Containers[0].Image = bpfdImage
 	staticBpfdDeployment.Spec.Template.Spec.Containers[1].Image = bpfdAgentImage
-	controllerutil.AddFinalizer(staticBpfdDeployment, "bpfd.dev.operator/finalizer")
+	controllerutil.AddFinalizer(staticBpfdDeployment, internal.BpfdOperatorFinalizer)
 
 	return staticBpfdDeployment
 }

--- a/bpfd-operator/internal/constants.go
+++ b/bpfd-operator/internal/constants.go
@@ -19,30 +19,47 @@ package internal
 import "fmt"
 
 const (
-	XdpProgramControllerFinalizer        = "bpfd.io.xdpprogramcontroller/finalizer"
-	TcProgramControllerFinalizer         = "bpfd.io.tcprogramcontroller/finalizer"
-	TracepointProgramControllerFinalizer = "bpfd.io.tracepointprogramcontroller/finalizer"
-	XdpProgramInterface                  = "bpfd.io.xdpprogramcontroller/interface"
-	TcProgramInterface                   = "bpfd.io.tcprogramcontroller/interface"
-	TracepointProgramTracepoint          = "bpfd.io.tracepointprogramcontroller/tracepoint"
-	BpfProgramOwnerLabel                 = "bpfd.io/ownedByProgram"
-	K8sHostLabel                         = "kubernetes.io/hostname"
-	BpfdNs                               = "bpfd"
-	BpfdOperatorName                     = "bpfd-operator"
-	BpfdDsName                           = "bpfd-daemon"
-	BpfdConfigName                       = "bpfd-config"
-	BpfdDaemonManifestPath               = "./config/bpfd-deployment/daemonset.yaml"
-	BpfdMapFs                            = "/run/bpfd/fs/maps"
-	DefaultConfigPath                    = "/etc/bpfd/bpfd.toml"
-	DefaultRootCaPath                    = "/etc/bpfd/certs/ca/ca.crt"
-	DefaultCertPath                      = "/etc/bpfd/certs/bpfd/tls.crt"
-	DefaultKeyPath                       = "/etc/bpfd/certs/bpfd/tls.key"
-	DefaultClientCertPath                = "/etc/bpfd/certs/bpfd-client/tls.crt"
-	DefaultClientKeyPath                 = "/etc/bpfd/certs/bpfd-client/tls.key"
-	DefaultType                          = "tcp"
-	DefaultPath                          = "/run/bpfd/bpfd.sock"
-	DefaultPort                          = 50051
-	DefaultEnabled                       = true
+	XdpProgramInterface         = "bpfd.dev.xdpprogramcontroller/interface"
+	TcProgramInterface          = "bpfd.dev.tcprogramcontroller/interface"
+	TracepointProgramTracepoint = "bpfd.dev.tracepointprogramcontroller/tracepoint"
+	BpfProgramOwnerLabel        = "bpfd.dev/ownedByProgram"
+	K8sHostLabel                = "kubernetes.io/hostname"
+	DiscoveredLabel             = "bpfd.dev/discoveredProgram"
+	BpfdNs                      = "bpfd"
+	BpfdOperatorName            = "bpfd-operator"
+	BpfdDsName                  = "bpfd-daemon"
+	BpfdConfigName              = "bpfd-config"
+	BpfdDaemonManifestPath      = "./config/bpfd-deployment/daemonset.yaml"
+	BpfdMapFs                   = "/run/bpfd/fs/maps"
+	DefaultConfigPath           = "/etc/bpfd/bpfd.toml"
+	DefaultRootCaPath           = "/etc/bpfd/certs/ca/ca.crt"
+	DefaultCertPath             = "/etc/bpfd/certs/bpfd/tls.crt"
+	DefaultKeyPath              = "/etc/bpfd/certs/bpfd/tls.key"
+	DefaultClientCertPath       = "/etc/bpfd/certs/bpfd-client/tls.crt"
+	DefaultClientKeyPath        = "/etc/bpfd/certs/bpfd-client/tls.key"
+	DefaultType                 = "tcp"
+	DefaultPath                 = "/run/bpfd/bpfd.sock"
+	DefaultPort                 = 50051
+	DefaultEnabled              = true
+)
+
+// -----------------------------------------------------------------------------
+// Finalizers
+// -----------------------------------------------------------------------------
+
+const (
+	// BpfdOperatorFinalizer is the finalizer that holds a *Program from
+	// deletion until cleanup can be performed.
+	BpfdOperatorFinalizer = "bpfd.dev.operator/finalizer"
+	// XdpProgramControllerFinalizer is the finalizer that holds an Xdp BpfProgram
+	// object from deletion until cleanup can be performed.
+	XdpProgramControllerFinalizer = "bpfd.dev.xdpprogramcontroller/finalizer"
+	// TcProgramControllerFinalizer is the finalizer that holds an Tc BpfProgram
+	// object from deletion until cleanup can be performed.
+	TcProgramControllerFinalizer = "bpfd.dev.tcprogramcontroller/finalizer"
+	// TracepointProgramControllerFinalizer is the finalizer that holds an Tracepoint
+	// BpfProgram object from deletion until cleanup can be performed.
+	TracepointProgramControllerFinalizer = "bpfd.dev.tracepointprogramcontroller/finalizer"
 )
 
 // Must match the internal bpfd-api mappings
@@ -87,13 +104,3 @@ func (p SupportedProgramType) String() string {
 		return ""
 	}
 }
-
-// -----------------------------------------------------------------------------
-// Finalizers
-// -----------------------------------------------------------------------------
-
-const (
-	// BpfdOperatorFinalizer is the finalizer that holds a BPF program from
-	// deletion until cleanup can be performed.
-	BpfdOperatorFinalizer = "bpfd.dev.operator/finalizer"
-)

--- a/bpfd-operator/internal/constants.go
+++ b/bpfd-operator/internal/constants.go
@@ -62,22 +62,52 @@ const (
 	TracepointProgramControllerFinalizer = "bpfd.dev.tracepointprogramcontroller/finalizer"
 )
 
-// Must match the internal bpfd-api mappings
-type SupportedProgramType int32
+// Must match the kernel's `bpf_prog_type` enum.
+// https://elixir.bootlin.com/linux/v6.4.4/source/include/uapi/linux/bpf.h#L948
+type ProgramType int32
 
 const (
-	Tc         SupportedProgramType = 3
-	Xdp        SupportedProgramType = 6
-	Tracepoint SupportedProgramType = 5
+	Unspec ProgramType = iota
+	SocketFilter
+	Kprobe
+	Tc
+	SchedAct
+	Tracepoint
+	Xdp
+	PerfEvent
+	CgroupSkb
+	CgroupSock
+	LwtIn
+	LwtOut
+	LwtXmit
+	SockOps
+	SkSkb
+	CgroupDevice
+	SkMsg
+	RawTracepoint
+	CgroupSockAddr
+	LwtSeg6Local
+	LircMode2
+	SkReuseport
+	FlowDissector
+	CgroupSysctl
+	RawTracepointWritable
+	CgroupSockopt
+	Tracing
+	StructOps
+	Ext
+	Lsm
+	SkLookup
+	Syscall
 )
 
-func (p SupportedProgramType) Uint32() *uint32 {
+func (p ProgramType) Uint32() *uint32 {
 	progTypeInt := uint32(p)
 	return &progTypeInt
 }
 
-func FromString(p string) (*SupportedProgramType, error) {
-	var programType SupportedProgramType
+func FromString(p string) (*ProgramType, error) {
+	var programType ProgramType
 	switch p {
 	case "tc":
 		programType = Tc
@@ -92,15 +122,73 @@ func FromString(p string) (*SupportedProgramType, error) {
 	return &programType, nil
 }
 
-func (p SupportedProgramType) String() string {
+func (p ProgramType) String() string {
 	switch p {
+	case Unspec:
+		return "unspec"
+	case SocketFilter:
+		return "socket_filter"
+	case Kprobe:
+		return "kprobe"
 	case Tc:
 		return "tc"
-	case Xdp:
-		return "xdp"
+	case SchedAct:
+		return "sched_act"
 	case Tracepoint:
 		return "tracepoint"
+	case Xdp:
+		return "xdp"
+	case PerfEvent:
+		return "perf_event"
+	case CgroupSkb:
+		return "cgroup_skb"
+	case CgroupSock:
+		return "cgroup_sock"
+	case LwtIn:
+		return "lwt_in"
+	case LwtOut:
+		return "lwt_out"
+	case LwtXmit:
+		return "lwt_xmit"
+	case SockOps:
+		return "sock_ops"
+	case SkSkb:
+		return "sk_skb"
+	case CgroupDevice:
+		return "cgroup_device"
+	case SkMsg:
+		return "sk_msg"
+	case RawTracepoint:
+		return "raw_tracepoint"
+	case CgroupSockAddr:
+		return "cgroup_sock_addr"
+	case LwtSeg6Local:
+		return "lwt_seg6local"
+	case LircMode2:
+		return "lirc_mode2"
+	case SkReuseport:
+		return "sk_reuseport"
+	case FlowDissector:
+		return "flow_dissector"
+	case CgroupSysctl:
+		return "cgroup_sysctl"
+	case RawTracepointWritable:
+		return "raw_tracepoint_writable"
+	case CgroupSockopt:
+		return "cgroup_sockopt"
+	case Tracing:
+		return "tracing"
+	case StructOps:
+		return "struct_ops"
+	case Ext:
+		return "ext"
+	case Lsm:
+		return "lsm"
+	case SkLookup:
+		return "sk_lookup"
+	case Syscall:
+		return "syscall"
 	default:
-		return ""
+		return "INVALID_PROG_TYPE"
 	}
 }


### PR DESCRIPTION
Works towards finishing #320 

This adds a new controller that creates bpfProgram object for programs not owned by bpfd.

These bpfProgram objects contain annotations which reflect kernel state as shown below

```bash
kubectl get bpfprograms -l bpfd.dev/unownedProgram -l kubernetes.io/hostname=bpfd-deployment-worker
NAME                                           AGE
dump-bpf-map-693-bpfd-deployment-worker        17h
dump-bpf-prog-694-bpfd-deployment-worker       17h
my-uretprobe-93125-bpfd-deployment-worker      17h
restrict-filesy-63130-bpfd-deployment-worker   17h
sd-fw-egress-63149-bpfd-deployment-worker      17h
sd-fw-egress-63171-bpfd-deployment-worker      17h
sd-fw-egress-63173-bpfd-deployment-worker      17h
sd-fw-egress-63175-bpfd-deployment-worker      17h
sd-fw-egress-63177-bpfd-deployment-worker      17h
sd-fw-ingress-63150-bpfd-deployment-worker     17h
sd-fw-ingress-63172-bpfd-deployment-worker     17h
sd-fw-ingress-63174-bpfd-deployment-worker     17h
sd-fw-ingress-63176-bpfd-deployment-worker     17h
sd-fw-ingress-63178-bpfd-deployment-worker     17h
```

```bash
kubectl get bpfprogram dump-bpf-map-693-bpfd-deployment-worker -o jsonpath='{.metadata.annotations}'

{"BTF-ID":"154","GPL-Compatible":"true","JITed":"true","Kernel-Allocated-Memory-Bytes":"4096","Kernel-ID":"693","Loaded-At":"2023-03-02T18:15:06+0000","Map-IDs":"[45]","Name":"dump_bpf_map","Size-JITed-Bytes":"287","Size-Translated-Bytes":"264","Tag":"749172daffada61f","Type":"tracing","Verified-Instruction-Count":"34"}
```

I decided to use annotations instead of status to store this metadata based on the existing [Kubernetes API conventions ](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)

More specifically Annotations should be used to 

```
annotations: a map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about this object (see [the annotations docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/))
```

and 

```
Annotations enable third-party automation and tooling to decorate objects with additional metadata for their own use.
```

While the status field contains conditions that

```
Conditions provide a standard mechanism for higher-level status reporting from a controller.
```

IMO in this case the metadata we're reporting to the users isn't actually a controller status, additionally there is no Key/Value store in the existing `metav1.Conditions` object which makes storing all the kernel information much more difficult. 

TODO

We still need to make sure a program loaded by bpfd ALSO get's these annotations, but that will require core some design changes to be done correctly so I'll work on it in another PR.

