### PR TITLE
bpfd-operator: Reduce the number of unload/reloads

### DIFF
--- a/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
@@ -220,7 +220,9 @@ func (r *TracepointProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 
 	r.Logger.V(1).WithValues("expectedProgram", loadRequest).WithValues("existingProgram", existingProgram).Info("StateMatch")
 	// BpfProgram exists but is not correct state, unload and recreate
-	if !bpfdagentinternal.DoesProgExist(existingProgram, loadRequest) {
+	isSame, reasons := bpfdagentinternal.DoesProgExist(existingProgram, loadRequest)
+	if !isSame {
+		r.Logger.V(1).Info("TracepointProgram is in wrong state, unloading and reloading", "Reason", reasons)
 		if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, id); err != nil {
 			r.Logger.Error(err, "Failed to unload TracepointProgram")
 			return bpfdiov1alpha1.BpfProgCondNotUnloaded, nil

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program.go
@@ -250,10 +250,10 @@ func (r *XdpProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 		return bpfdiov1alpha1.BpfProgCondNotSelected, nil
 	}
 
-	r.Logger.V(1).WithValues("expectedProgram", loadRequest).WithValues("existingProgram", existingProgram).Info("StateMatch")
 	// BpfProgram exists but is not correct state, unload and recreate
-	if !bpfdagentinternal.DoesProgExist(existingProgram, loadRequest) {
-		r.Logger.V(1).Info("XdpProgram is in wrong state, unloading and reloading")
+	isSame, reasons := bpfdagentinternal.DoesProgExist(existingProgram, loadRequest)
+	if !isSame {
+		r.Logger.V(1).Info("XdpProgram is in wrong state, unloading and reloading", "Reason", reasons)
 		if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, id); err != nil {
 			r.Logger.Error(err, "Failed to unload XdpProgram")
 			return bpfdiov1alpha1.BpfProgCondNotUnloaded, nil


### PR DESCRIPTION
In bpfd-operator, the compare function DoesProgExist() compares the current LoadRequest values to the what is loaded in bpfd in the ListResult. The compare was comparing the pointer values of the Id instead of the actual strings, so it always indicated that there change. This caused the calling function to always unload and reload the EBPF Program.