### PR TITLE
move direction to tcInfo

### DIFF
--- a/bpfd/src/bpf.rs
+++ b/bpfd/src/bpf.rs
@@ -725,7 +725,7 @@ impl BpfManager {
                                     iface: p.info.if_name.to_string(),
                                     priority: p.info.metadata.priority,
                                     proceed_on: p.info.proceed_on.clone(),
-                                    direction: p.direction,
+                                    direction: p.info.direction,
                                     position: p.info.current_position.unwrap_or_default() as i32,
                                 },
                             )),
@@ -957,7 +957,6 @@ impl BpfManager {
                 Ok(prog_data) => {
                     let prog = Program::Tc(TcProgram {
                         data: prog_data.clone(),
-                        direction: args.direction,
                         info: TcProgramInfo {
                             if_index,
                             current_position: None,
@@ -969,6 +968,7 @@ impl BpfManager {
                             },
                             proceed_on: args.proceed_on,
                             if_name: args.iface,
+                            direction: args.direction,
                         },
                     });
                     self.add_program(prog, args.id).await

--- a/bpfd/src/command.rs
+++ b/bpfd/src/command.rs
@@ -316,7 +316,6 @@ impl XdpProgram {
 pub(crate) struct TcProgram {
     pub(crate) data: ProgramData,
     pub(crate) info: TcProgramInfo,
-    pub(crate) direction: Direction,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -355,6 +354,8 @@ impl UprobeProgram {
     }
 }
 
+// ProgramData represents all of the core information needed to load
+// a program reguardless of ProgramType.
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct ProgramData {
     pub(crate) location: Location,
@@ -436,6 +437,7 @@ pub(crate) struct TcProgramInfo {
     pub(crate) current_position: Option<usize>,
     pub(crate) metadata: Metadata,
     pub(crate) proceed_on: TcProceedOn,
+    pub(crate) direction: Direction,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -477,7 +479,7 @@ impl Program {
             Program::Xdp(p) => Some(DispatcherId::Xdp(DispatcherInfo(p.info.if_index, None))),
             Program::Tc(p) => Some(DispatcherId::Tc(DispatcherInfo(
                 p.info.if_index,
-                Some(p.direction),
+                Some(p.info.direction),
             ))),
             _ => None,
         }
@@ -596,7 +598,7 @@ impl Program {
         match self {
             Program::Xdp(_) => None,
             Program::Tracepoint(_) => None,
-            Program::Tc(p) => Some(p.direction),
+            Program::Tc(p) => Some(p.info.direction),
             Program::Kprobe(_) => None,
             Program::Uprobe(_) => None,
         }

--- a/bpfd/src/static_program.rs
+++ b/bpfd/src/static_program.rs
@@ -145,13 +145,13 @@ pub(crate) async fn get_static_programs<P: AsRef<Path>>(
                                 String::from("bpfd"),
                             )
                             .await?,
-                            direction: m.direction,
                             info: TcProgramInfo {
                                 if_index,
                                 current_position: None,
                                 metadata,
                                 proceed_on: m.proceed_on,
                                 if_name: m.iface,
+                                direction: m.direction,
                             },
                         })
                     } else {


### PR DESCRIPTION
The direction field for tc programs was at the wrong level internally fix this by moving the field into tcProgramInfo. Add a comment to `ProgramData`.