### PR TITLE
Remove check to block unloading of a Map Owner

### DIFF
--- a/docs/getting-started/bpfctl-guide.md
+++ b/docs/getting-started/bpfctl-guide.md
@@ -313,17 +313,8 @@ set to same directory as the first program, which includes the first program's U
 The output for both commands shows the map is being used by the second program via
 the `Map Used By` with a value of `d6939812-5f6a-42ff-9b55-d3668d8527d0`.
 
-The eBPF program that owns the maps cannot be unloaded until all eBPF programs
-referencing the maps have been unloaded.
-Otherwise an error will be returned:
-
-```console
-bpfctl unload 87100e16-4481-4f97-be89-f68d269d6062
-Error = status: Aborted, message: "An error occurred. map being used by other eBPF program", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Mon, 17 Jul 2023 20:30:42 GMT", "content-length": "0"} }
-Error: Failed to execute request
-```
-
-So first unload the eBPF program referencing the map, then unload the map owner:
+The eBPF programs can be unloaded any order, the `Map Pin Path` will not be deleted
+until all the programs referencing the maps are unloaded:
 
 ```console
 bpfctl unload d6939812-5f6a-42ff-9b55-d3668d8527d0


### PR DESCRIPTION
There was a check in bpfd which prevent an eBPF program from being deleted if it's maps were being referenced by another eBPF Program. The check was added during the original map sharing PR because it caused problems, but that is no longer the case.

bpfd used to remove the Map Owner from the list of UUIDs in the MapsUsedBy field, because it looked cleaner. The Map Owner is now included in the list of UUIDs in the MapsUsedBy because the Map Owner eBPF Program can now be unloaded, so it is useful to know if it is there or not.