### PR TITLE
Fix  bpfd-agent race

### DIFF
--- a/bpfd-operator/controllers/bpfd-agent/discovered_program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/discovered_program_test.go
@@ -137,7 +137,6 @@ func TestDiscoveredProgramControllerCreate(t *testing.T) {
 		Scheme:       s,
 		BpfdClient:   cli,
 		NodeName:     fakeNode.Name,
-		bpfPrograms:  map[string]bpfdiov1alpha1.BpfProgram{},
 		expectedMaps: map[string]string{},
 	}
 
@@ -321,7 +320,6 @@ func TestDiscoveredProgramControllerCreateAndDeleteStale(t *testing.T) {
 		Scheme:       s,
 		BpfdClient:   cli,
 		NodeName:     fakeNode.Name,
-		bpfPrograms:  map[string]bpfdiov1alpha1.BpfProgram{},
 		expectedMaps: map[string]string{},
 	}
 

--- a/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
@@ -85,7 +85,7 @@ func (r *KprobeProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *KprobeProgramReconciler) buildBpfPrograms(ctx context.Context) (*bpfdiov1alpha1.BpfProgramList, error) {
+func (r *KprobeProgramReconciler) expectedBpfPrograms(ctx context.Context) (*bpfdiov1alpha1.BpfProgramList, error) {
 	progs := &bpfdiov1alpha1.BpfProgramList{}
 
 	for _, function := range r.currentKprobeProgram.Spec.FunctionNames {

--- a/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
@@ -138,8 +138,8 @@ func (r *KprobeProgramReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationAgent}, nil
 	}
 
-	// Reconcile every KprobeProgram Object
-	// note: This doesn't necessarily result in any extra grpc calls to bpfd
+	// Reconcile each KprobeProgram. Don't return error here because it will trigger an infinite reconcile loop, instead
+	// report the error to user and retry if specified. For some errors the controller may not decide to retry.
 	for _, kprobeProgram := range kprobePrograms.Items {
 		r.Logger.Info("KprobeProgramController is reconciling", "key", req)
 		r.currentKprobeProgram = &kprobeProgram

--- a/bpfd-operator/controllers/bpfd-agent/kprobe-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/kprobe-program_test.go
@@ -97,7 +97,6 @@ func TestKprobeProgramControllerCreate(t *testing.T) {
 		Scheme:       s,
 		BpfdClient:   cli,
 		NodeName:     fakeNode.Name,
-		bpfPrograms:  map[string]bpfdiov1alpha1.BpfProgram{},
 		expectedMaps: map[string]string{},
 	}
 

--- a/bpfd-operator/controllers/bpfd-agent/tc-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program.go
@@ -174,8 +174,8 @@ func (r *TcProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationAgent}, nil
 	}
 
-	// Reconcile every TcProgram Object
-	// note: This doesn't necessarily result in any extra grpc calls to bpfd
+	// Reconcile each TcProgram. Don't return error here because it will trigger an infinite reconcile loop, instead
+	// report the error to user and retry if specified. For some errors the controller may not decide to retry.
 	for _, tcProgram := range tcPrograms.Items {
 		r.Logger.Info("TcProgramController is reconciling", "key", req)
 		r.currentTcProgram = &tcProgram

--- a/bpfd-operator/controllers/bpfd-agent/tc-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program.go
@@ -124,7 +124,7 @@ func (r *TcProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *TcProgramReconciler) buildBpfPrograms(ctx context.Context) (*bpfdiov1alpha1.BpfProgramList, error) {
+func (r *TcProgramReconciler) expectedBpfPrograms(ctx context.Context) (*bpfdiov1alpha1.BpfProgramList, error) {
 	progs := &bpfdiov1alpha1.BpfProgramList{}
 	for _, iface := range r.interfaces {
 		bpfProgramName := fmt.Sprintf("%s-%s-%s", r.currentTcProgram.Name, r.NodeName, iface)

--- a/bpfd-operator/controllers/bpfd-agent/tc-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program_test.go
@@ -102,7 +102,6 @@ func TestTcProgramControllerCreate(t *testing.T) {
 		Scheme:       s,
 		BpfdClient:   cli,
 		NodeName:     fakeNode.Name,
-		bpfPrograms:  map[string]bpfdiov1alpha1.BpfProgram{},
 		expectedMaps: map[string]string{},
 	}
 
@@ -268,7 +267,6 @@ func TestTcProgramControllerCreateMultiIntf(t *testing.T) {
 		Scheme:       s,
 		BpfdClient:   cli,
 		NodeName:     fakeNode.Name,
-		bpfPrograms:  map[string]bpfdiov1alpha1.BpfProgram{},
 		expectedMaps: map[string]string{},
 	}
 
@@ -314,7 +312,16 @@ func TestTcProgramControllerCreateMultiIntf(t *testing.T) {
 	err = cl.Update(ctx, bpfProgEth0)
 	require.NoError(t, err)
 
-	// Second reconcile should create the second bpf program object
+	// Second reconcile should create the bpfd Load Requests for the first bpfProgram.
+	res, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	// Require no requeue
+	require.False(t, res.Requeue)
+
+	// Third reconcile should create the second bpf program object
 	res, err = r.Reconcile(ctx, req)
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
@@ -340,15 +347,6 @@ func TestTcProgramControllerCreateMultiIntf(t *testing.T) {
 	bpfProgEth1.UID = types.UID(fakeUID1)
 	err = cl.Update(ctx, bpfProgEth1)
 	require.NoError(t, err)
-
-	// Third reconcile should create the bpfd Load Requests for the first bpfProgram.
-	res, err = r.Reconcile(ctx, req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	// Require no requeue
-	require.False(t, res.Requeue)
 
 	// Fourth reconcile should create the bpfd Load Requests for the second bpfProgram.
 	res, err = r.Reconcile(ctx, req)

--- a/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
@@ -138,8 +138,8 @@ func (r *TracepointProgramReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationAgent}, nil
 	}
 
-	// Reconcile every TracepointProgram Object
-	// note: This doesn't necessarily result in any extra grpc calls to bpfd
+	// Reconcile each Tracepoint. Don't return error here because it will trigger an infinite reconcile loop, instead
+	// report the error to user and retry if specified. For some errors the controller may not decide to retry.
 	for _, tracepointProgram := range tracepointPrograms.Items {
 		r.Logger.Info("TracepointProgramController is reconciling", "key", req)
 		r.currentTracepointProgram = &tracepointProgram

--- a/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
@@ -85,7 +85,7 @@ func (r *TracepointProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *TracepointProgramReconciler) buildBpfPrograms(ctx context.Context) (*bpfdiov1alpha1.BpfProgramList, error) {
+func (r *TracepointProgramReconciler) expectedBpfPrograms(ctx context.Context) (*bpfdiov1alpha1.BpfProgramList, error) {
 	progs := &bpfdiov1alpha1.BpfProgramList{}
 
 	for _, tracepoint := range r.currentTracepointProgram.Spec.Names {

--- a/bpfd-operator/controllers/bpfd-agent/tracepoint-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/tracepoint-program_test.go
@@ -92,7 +92,6 @@ func TestTracepointProgramControllerCreate(t *testing.T) {
 		Scheme:       s,
 		BpfdClient:   cli,
 		NodeName:     fakeNode.Name,
-		bpfPrograms:  map[string]bpfdiov1alpha1.BpfProgram{},
 		expectedMaps: map[string]string{},
 	}
 

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program.go
@@ -172,6 +172,8 @@ func (r *XdpProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{Requeue: true, RequeueAfter: retryDurationAgent}, nil
 		}
 
+		// Reconcile each XdpProgram. Don't return error here because it will trigger an infinite reconcile loop, instead
+		// report the error to user and retry if specified. For some errors the controller may not decide to retry.
 		retry, err := reconcileProgram(ctx, r, r.currentXdpProgram, &r.currentXdpProgram.Spec.BpfProgramCommon, r.ourNode, programMap)
 		if err != nil {
 			r.Logger.Error(err, "Reconciling XdpProgram Failed", "XdpProgramName", r.currentXdpProgram.Name, "Retrying", retry)

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program.go
@@ -109,7 +109,7 @@ func (r *XdpProgramReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *XdpProgramReconciler) buildBpfPrograms(ctx context.Context) (*bpfdiov1alpha1.BpfProgramList, error) {
+func (r *XdpProgramReconciler) expectedBpfPrograms(ctx context.Context) (*bpfdiov1alpha1.BpfProgramList, error) {
 	progs := &bpfdiov1alpha1.BpfProgramList{}
 
 	for _, iface := range r.interfaces {

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program_test.go
@@ -97,7 +97,6 @@ func TestXdpProgramControllerCreate(t *testing.T) {
 		Scheme:       s,
 		BpfdClient:   cli,
 		NodeName:     fakeNode.Name,
-		bpfPrograms:  map[string]bpfdiov1alpha1.BpfProgram{},
 		expectedMaps: map[string]string{},
 	}
 
@@ -258,7 +257,6 @@ func TestXdpProgramControllerCreateMultiIntf(t *testing.T) {
 		Scheme:       s,
 		BpfdClient:   cli,
 		NodeName:     fakeNode.Name,
-		bpfPrograms:  map[string]bpfdiov1alpha1.BpfProgram{},
 		expectedMaps: map[string]string{},
 	}
 
@@ -304,7 +302,16 @@ func TestXdpProgramControllerCreateMultiIntf(t *testing.T) {
 	err = cl.Update(ctx, bpfProgEth0)
 	require.NoError(t, err)
 
-	// Second reconcile should create the second bpf program object
+	// Second reconcile should create the bpfd Load Requests for the first bpfProgram.
+	res, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	// Require no requeue
+	require.False(t, res.Requeue)
+
+	// Third reconcile should create the second bpf program object
 	res, err = r.Reconcile(ctx, req)
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
@@ -330,15 +337,6 @@ func TestXdpProgramControllerCreateMultiIntf(t *testing.T) {
 	bpfProgEth1.UID = types.UID(fakeUID1)
 	err = cl.Update(ctx, bpfProgEth1)
 	require.NoError(t, err)
-
-	// Third reconcile should create the bpfd Load Requests for the first bpfProgram.
-	res, err = r.Reconcile(ctx, req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	// Require no requeue
-	require.False(t, res.Requeue)
 
 	// Fourth reconcile should create the bpfd Load Requests for the second bpfProgram.
 	res, err = r.Reconcile(ctx, req)

--- a/bpfd-operator/controllers/bpfd-operator/common.go
+++ b/bpfd-operator/controllers/bpfd-operator/common.go
@@ -120,7 +120,8 @@ func reconcileBpfProgram(ctx context.Context, rec ProgramReconciler, prog client
 	}
 
 	if !prog.GetDeletionTimestamp().IsZero() {
-		// Only remove bpfd-operator finalizer if all bpfProgram Objects are ready to be pruned  (i.e finalizers have been removed)
+		// Only remove bpfd-operator finalizer if all bpfProgram Objects are ready to be pruned  (i.e there are no
+		// bpfPrograms with a finalizer)
 		if len(finalApplied) == 0 {
 			// Causes Requeue
 			return r.removeFinalizer(ctx, prog, internal.BpfdOperatorFinalizer)

--- a/bpfd-operator/hack/kind-config.yaml
+++ b/bpfd-operator/hack/kind-config.yaml
@@ -2,5 +2,3 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-- role: worker
-- role: worker

--- a/bpfd/src/oci_utils/image_manager.rs
+++ b/bpfd/src/oci_utils/image_manager.rs
@@ -434,7 +434,7 @@ mod tests {
 
     #[tokio::test]
     #[should_panic]
-    async fn private_image_pull_faiure() {
+    async fn private_image_pull_failure() {
         let tmpdir = tempfile::tempdir().unwrap();
         std::env::set_current_dir(&tmpdir).unwrap();
 


### PR DESCRIPTION
fix a race that @Billy99 found where we were creating a bpfProgram even though the parent *Program was being deleted.

In the meantime try and cleanup the core shared code to be a bit easier to understand. 

Functionally the main change here is that now a given BpfProgram will be created and reconciled in the same loop meaning that all bpfProgram objects wont be created before any program is actually loaded via bpfd.