### PR TITLE
Handle and report bytecode selector errors

### DIFF
--- a/bpfd-operator/apis/v1alpha1/shared_types.go
+++ b/bpfd-operator/apis/v1alpha1/shared_types.go
@@ -237,9 +237,13 @@ const (
 	// BpfProgCondMapOwnerNotLoaded indicates that the eBPF program sharing a map with another
 	// eBPF program and that program is not loaded.
 	BpfProgCondMapOwnerNotLoaded BpfProgramConditionType = "MapOwnerNotLoaded"
+
 	// BpfProgCondByteCodeError indicates that an error occured when trying to
 	// process the bytecode selector.
 	BpfProgCondBytecodeSelectorError BpfProgramConditionType = "BytecodeSelectorError"
+
+	// None of the above conditions apply
+	BpfProgCondNone BpfProgramConditionType = "None"
 )
 
 // Condition is a helper method to promote any given BpfProgramConditionType to
@@ -304,6 +308,14 @@ func (b BpfProgramConditionType) Condition() metav1.Condition {
 			Status:  metav1.ConditionTrue,
 			Reason:  "bytecodeSelectorError",
 			Message: "There was an error processing the provided bytecode selector",
+		}
+
+	case BpfProgCondNone:
+		cond = metav1.Condition{
+			Type:    string(BpfProgCondNone),
+			Status:  metav1.ConditionTrue,
+			Reason:  "None",
+			Message: "None of the conditions apply",
 		}
 	}
 

--- a/bpfd-operator/apis/v1alpha1/shared_types.go
+++ b/bpfd-operator/apis/v1alpha1/shared_types.go
@@ -237,6 +237,9 @@ const (
 	// BpfProgCondMapOwnerNotLoaded indicates that the eBPF program sharing a map with another
 	// eBPF program and that program is not loaded.
 	BpfProgCondMapOwnerNotLoaded BpfProgramConditionType = "MapOwnerNotLoaded"
+	// BpfProgCondByteCodeError indicates that an error occured when trying to
+	// process the bytecode selector.
+	BpfProgCondBytecodeSelectorError BpfProgramConditionType = "BytecodeSelectorError"
 )
 
 // Condition is a helper method to promote any given BpfProgramConditionType to
@@ -293,6 +296,14 @@ func (b BpfProgramConditionType) Condition() metav1.Condition {
 			Status:  metav1.ConditionTrue,
 			Reason:  "mapOwnerNotLoaded",
 			Message: "BpfProgram map owner not loaded",
+		}
+
+	case BpfProgCondBytecodeSelectorError:
+		cond = metav1.Condition{
+			Type:    string(BpfProgCondBytecodeSelectorError),
+			Status:  metav1.ConditionTrue,
+			Reason:  "bytecodeSelectorError",
+			Message: "There was an error processing the provided bytecode selector",
 		}
 	}
 

--- a/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
@@ -147,21 +147,17 @@ func (r *KprobeProgramReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		r.currentKprobeProgram = &kprobeProgram
 		result, err := reconcileProgram(ctx, r, r.currentKprobeProgram, &r.currentKprobeProgram.Spec.BpfProgramCommon, r.ourNode, programMap)
 		if err != nil {
-			r.Logger.Error(err, "Reconciling KprobeProgram Failed", "KprobeProgramName", r.currentKprobeProgram.Name, "ReconcileResult", ReconcileResultToString(result))
+			r.Logger.Error(err, "Reconciling KprobeProgram Failed", "KprobeProgramName", r.currentKprobeProgram.Name, "ReconcileResult", result.String())
 		}
 
 		switch result {
-		case Unchanged:
-			// Nothing changed, so continue to the next program in the list if there is one.
-		case Updated:
-			// Since a k8s object has been updated that will trigger a new
-			// reconcile for this object type, we want to exit the loop now to
-			// avoid having multiple reconciles happening concurrently.
+		case internal.Unchanged:
+			// continue with next program
+		case internal.Updated:
+			// return
 			return ctrl.Result{Requeue: false}, nil
-		case Requeue:
-			// A requeue has been requested.  Since there weren't any changes to
-			// k8s objects, we don't need to exit this loop now and can continue
-			// processing the rest of the programs in the list.
+		case internal.Requeue:
+			// remember to do a requeue when we're done and continue with next program
 			requeue = true
 		}
 	}
@@ -217,6 +213,15 @@ func (r *KprobeProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 
 	id := string(bpfProgram.UID)
 
+	getLoadRequest := func() (*gobpfd.LoadRequest, bpfdiov1alpha1.BpfProgramConditionType, error) {
+		bytecode, err := bpfdagentinternal.GetBytecode(r.Client, bytecodeSelector)
+		if err != nil {
+			return nil, bpfdiov1alpha1.BpfProgCondBytecodeSelectorError, fmt.Errorf("failed to process bytecode selector: %v", err)
+		}
+		loadRequest := r.buildKprobeLoadRequest(bytecode, id, bpfProgram, mapOwnerStatus.mapOwnerUuid)
+		return loadRequest, bpfdiov1alpha1.BpfProgCondNone, nil
+	}
+
 	existingProgram, doesProgramExist := existingBpfPrograms[id]
 	if !doesProgramExist {
 		r.Logger.V(1).Info("KprobeProgram doesn't exist on node")
@@ -242,12 +247,10 @@ func (r *KprobeProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 		}
 
 		// otherwise load it
-		bytecode, err := bpfdagentinternal.GetBytecode(r.Client, bytecodeSelector)
+		loadRequest, condition, err := getLoadRequest()
 		if err != nil {
-			return bpfdiov1alpha1.BpfProgCondBytecodeSelectorError, fmt.Errorf("failed to process bytecode selector: %v", err)
+			return condition, err
 		}
-
-		loadRequest := r.buildKprobeLoadRequest(bytecode, id, bpfProgram, mapOwnerStatus.mapOwnerUuid)
 
 		bpfProgramEntry, err := bpfdagentinternal.LoadBpfdProgram(ctx, r.BpfdClient, loadRequest)
 		if err != nil {
@@ -292,12 +295,10 @@ func (r *KprobeProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 	}
 
 	// BpfProgram exists but is not correct state, unload and recreate
-	bytecode, err := bpfdagentinternal.GetBytecode(r.Client, bytecodeSelector)
+	loadRequest, condition, err := getLoadRequest()
 	if err != nil {
-		return bpfdiov1alpha1.BpfProgCondBytecodeSelectorError, fmt.Errorf("failed to process bytecode selector: %v", err)
+		return condition, err
 	}
-
-	loadRequest := r.buildKprobeLoadRequest(bytecode, id, bpfProgram, mapOwnerStatus.mapOwnerUuid)
 
 	r.Logger.V(1).WithValues("expectedProgram", loadRequest).WithValues("existingProgram", existingProgram).Info("StateMatch")
 

--- a/bpfd-operator/controllers/bpfd-agent/tc-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program.go
@@ -176,6 +176,8 @@ func (r *TcProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Reconcile each TcProgram. Don't return error here because it will trigger an infinite reconcile loop, instead
 	// report the error to user and retry if specified. For some errors the controller may not decide to retry.
+	// Note: This only results in grpc calls to bpfd if we need to change something
+	requeue := false // initialize requeue to false
 	for _, tcProgram := range tcPrograms.Items {
 		r.Logger.Info("TcProgramController is reconciling", "key", req)
 		r.currentTcProgram = &tcProgram
@@ -186,14 +188,34 @@ func (r *TcProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{Requeue: true, RequeueAfter: retryDurationAgent}, nil
 		}
 
-		retry, err := reconcileProgram(ctx, r, r.currentTcProgram, &r.currentTcProgram.Spec.BpfProgramCommon, r.ourNode, existingPrograms)
+		result, err := reconcileProgram(ctx, r, r.currentTcProgram, &r.currentTcProgram.Spec.BpfProgramCommon, r.ourNode, existingPrograms)
 		if err != nil {
-			r.Logger.Error(err, "Reconciling TcProgram Failed", "TcProgramName", r.currentTcProgram.Name, "Retrying", retry)
-			return ctrl.Result{Requeue: retry, RequeueAfter: retryDurationAgent}, nil
+			r.Logger.Error(err, "Reconciling TcProgram Failed", "TcProgramName", r.currentTcProgram.Name, "ReconcileResult", ReconcileResultToString(result))
+		}
+		switch result {
+		case Unchanged:
+			// Nothing changed, so continue to the next program in the list if there is one.
+		case Updated:
+			// Since a k8s object has been updated that will trigger a new
+			// reconcile for this object type, we want to exit the loop now to
+			// avoid having multiple reconciles happening concurrently.
+			return ctrl.Result{Requeue: false}, nil
+		case Requeue:
+			// A requeue has been requested.  Since there weren't any changes to
+			// k8s objects, we don't need to exit this loop now and can continue
+			// processing the rest of the programs in the list.
+			requeue = true
 		}
 	}
 
-	return ctrl.Result{Requeue: false}, nil
+	if requeue {
+		// A requeue has been requested
+		return ctrl.Result{RequeueAfter: retryDurationAgent}, nil
+	} else {
+		// We've made it through all the programs in the list without anything being
+		// updated and a reque has not been requested.
+		return ctrl.Result{Requeue: false}, nil
+	}
 }
 
 func (r *TcProgramReconciler) buildTcLoadRequest(

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program.go
@@ -160,8 +160,10 @@ func (r *XdpProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	r.Logger.V(1).WithValues("loaded-xdp-programs", programMap).Info("Existing XDP programs")
 
-	// Reconcile every XdpProgram Object
-	// note: This doesn't necessarily result in any extra grpc calls to bpfd
+	// Reconcile each XdpProgram. Don't return error here because it will trigger an infinite reconcile loop, instead
+	// report the error to user and retry if specified. For some errors the controller may not decide to retry.
+	// Note: This only results in grpc calls to bpfd if we need to change something
+	requeue := false // initialize requeue to false
 	for _, xdpProgram := range xdpPrograms.Items {
 		r.Logger.Info("XdpProgramController is reconciling", "currentXdpProgram", xdpProgram.Name)
 		r.currentXdpProgram = &xdpProgram
@@ -174,14 +176,35 @@ func (r *XdpProgramReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		// Reconcile each XdpProgram. Don't return error here because it will trigger an infinite reconcile loop, instead
 		// report the error to user and retry if specified. For some errors the controller may not decide to retry.
-		retry, err := reconcileProgram(ctx, r, r.currentXdpProgram, &r.currentXdpProgram.Spec.BpfProgramCommon, r.ourNode, programMap)
+		result, err := reconcileProgram(ctx, r, r.currentXdpProgram, &r.currentXdpProgram.Spec.BpfProgramCommon, r.ourNode, programMap)
 		if err != nil {
-			r.Logger.Error(err, "Reconciling XdpProgram Failed", "XdpProgramName", r.currentXdpProgram.Name, "Retrying", retry)
-			return ctrl.Result{Requeue: retry, RequeueAfter: retryDurationAgent}, nil
+			r.Logger.Error(err, "Reconciling XdpProgram Failed", "XdpProgramName", r.currentXdpProgram.Name, "ReconcileResult", ReconcileResultToString(result))
+		}
+
+		switch result {
+		case Unchanged:
+			// Nothing changed, so continue to the next program in the list if there is one.
+		case Updated:
+			// Since a k8s object has been updated that will trigger a new
+			// reconcile for this object type, we want to exit the loop now to
+			// avoid having multiple reconciles happening concurrently.
+			return ctrl.Result{Requeue: false}, nil
+		case Requeue:
+			// A requeue has been requested.  Since there weren't any changes to
+			// k8s objects, we don't need to exit this loop now and can continue
+			// processing the rest of the programs in the list.
+			requeue = true
 		}
 	}
 
-	return ctrl.Result{Requeue: false}, nil
+	if requeue {
+		// A requeue has been requested
+		return ctrl.Result{RequeueAfter: retryDurationAgent}, nil
+	} else {
+		// We've made it through all the programs in the list without anything being
+		// updated and a reque has not been requested.
+		return ctrl.Result{Requeue: false}, nil
+	}
 }
 
 func (r *XdpProgramReconciler) buildXdpLoadRequest(

--- a/bpfd-operator/controllers/bpfd-operator/common.go
+++ b/bpfd-operator/controllers/bpfd-operator/common.go
@@ -82,7 +82,7 @@ func reconcileBpfProgram(ctx context.Context, rec ProgramReconciler, prog client
 		return ctrl.Result{}, nil
 	}
 
-	// List all nodes since an bpfprogram object will always be created for each
+	// List all nodes since a bpfprogram object will always be created for each
 	nodes := &corev1.NodeList{}
 	if err := r.List(ctx, nodes, &client.ListOptions{}); err != nil {
 		r.Logger.Error(err, "failed getting nodes for full reconcile")

--- a/bpfd-operator/internal/constants.go
+++ b/bpfd-operator/internal/constants.go
@@ -198,3 +198,34 @@ func (p ProgramType) String() string {
 		return "INVALID_PROG_TYPE"
 	}
 }
+
+type ReconcileResult uint8
+
+const (
+	// No changes were made to k8s objects, and rescheduling another reconcile
+	// is not necessary. The calling code may continue reconciling other
+	// programs in it's list.
+	Unchanged ReconcileResult = 0
+	// Changes were made to k8s objects that we know will trigger another
+	// reconcile.  Calling code should stop reconciling additional programs and
+	// return immediately to avoid multiple concurrent reconcile threads.
+	Updated ReconcileResult = 1
+	// A retry should be scheduled. This should only be used when "Updated"
+	// doesn't apply, but we want to trigger another reconcile anyway.  For
+	// example, there was a transient error. The calling code may continue
+	// reconciling other programs in it's list.
+	Requeue ReconcileResult = 2
+)
+
+func (r ReconcileResult) String() string {
+	switch r {
+	case Unchanged:
+		return "Unchanged"
+	case Updated:
+		return "Updated"
+	case Requeue:
+		return "Requeue"
+	default:
+		return fmt.Sprintf("INVALID RECONCILE RESULT (%d)", r)
+	}
+}

--- a/bpfd-operator/pkg/helpers/helpers.go
+++ b/bpfd-operator/pkg/helpers/helpers.go
@@ -440,7 +440,8 @@ func IsBpfProgramConditionFailure(conditionType string) bool {
 	if conditionType == string(bpfdiov1alpha1.BpfProgCondNotLoaded) ||
 		conditionType == string(bpfdiov1alpha1.BpfProgCondNotUnloaded) ||
 		conditionType == string(bpfdiov1alpha1.BpfProgCondMapOwnerNotFound) ||
-		conditionType == string(bpfdiov1alpha1.BpfProgCondMapOwnerNotLoaded) {
+		conditionType == string(bpfdiov1alpha1.BpfProgCondMapOwnerNotLoaded) ||
+		conditionType == string(bpfdiov1alpha1.BpfProgCondBytecodeSelectorError) {
 		return true
 	}
 


### PR DESCRIPTION
With the original bug, if there was a problem with GetBytecode(), the bpfProgram object would have been created, but the program would fail to load because GetBytecode() would fail and return.  We didn’t tell the user why it failed and you couldn’t delete the *program object because in order to do that, you need to call reconcileBpfdProgram(), which requires the bytecode interface.

Andrew’s recent pr changed the behavior so that the bpfProgram objects get created only after the GetBytecode() succeeds.  This is better because you don’t have the bpfProgram object that can’t be deleted, but because you don’t have the bpfProgram object, you don’t know why it failed unless you look at the agent logs.

Both versions still had a problem where if the secret gets deleted (or changed so it doesn’t work after a bpf program is loaded) you can’t unload programs that use it even though the bytecode  interface isn’t necessary for unloading programs.

This pr moves the GetBytecode() call into reconcileBpfdProgram(), and only calls it when we need to do a load.  This allows the bpfProgram object to get created and reports the error with a new condition called BpfProgCondBytecodeSelectorError.  It also allows you to delete the program.

This pr also changes the result returned from reconcileProgram to one of "Unchanged", "Updated", or "Requeue".

Fixes: issue #640