### PR TITLE
simplify internal API

### DIFF
--- a/bpfd/src/command.rs
+++ b/bpfd/src/command.rs
@@ -2,7 +2,12 @@
 // Copyright Authors of bpfd
 
 //! Commands between the RPC thread and the BPF thread
-use std::{collections::HashMap, fmt, fs, io::BufReader, path::PathBuf};
+use std::{
+    collections::HashMap,
+    fmt, fs,
+    io::BufReader,
+    path::{Path, PathBuf},
+};
 
 use aya::programs::ProgramInfo as AyaProgInfo;
 use bpfd_api::{
@@ -28,100 +33,34 @@ type Responder<T> = oneshot::Sender<T>;
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Command {
-    /// Load an XDP program
-    LoadXDP(LoadXDPArgs),
-    /// Load a TC program
-    LoadTC(LoadTCArgs),
-    // Load a Tracepoint program
-    LoadTracepoint(LoadTracepointArgs),
-    // Load a kprobe program
-    LoadKprobe(LoadKprobeArgs),
-    // Load a uprobe program
-    LoadUprobe(LoadUprobeArgs),
+    /// Load a program
+    Load(LoadArgs),
     Unload(UnloadArgs),
     List {
-        responder: Responder<Result<Vec<ProgramInfo>, BpfdError>>,
+        responder: Responder<Result<Vec<Program>, BpfdError>>,
     },
     PullBytecode(PullBytecodeArgs),
 }
 
 #[derive(Debug)]
-pub(crate) struct LoadXDPArgs {
-    pub(crate) location: Location,
-    pub(crate) section_name: String,
-    pub(crate) id: Option<Uuid>,
-    pub(crate) global_data: HashMap<String, Vec<u8>>,
-    pub(crate) map_owner_uuid: Option<Uuid>,
-    pub(crate) iface: String,
-    pub(crate) priority: i32,
-    pub(crate) proceed_on: XdpProceedOn,
-    pub(crate) username: String,
+pub(crate) struct LoadArgs {
+    pub(crate) program: Program,
     pub(crate) responder: Responder<Result<Uuid, BpfdError>>,
 }
 
-#[derive(Debug)]
-pub(crate) struct LoadTCArgs {
-    pub(crate) location: Location,
-    pub(crate) section_name: String,
-    pub(crate) id: Option<Uuid>,
-    pub(crate) global_data: HashMap<String, Vec<u8>>,
-    pub(crate) map_owner_uuid: Option<Uuid>,
-    pub(crate) iface: String,
-    pub(crate) priority: i32,
-    pub(crate) direction: Direction,
-    pub(crate) proceed_on: TcProceedOn,
-    pub(crate) username: String,
-    pub(crate) responder: Responder<Result<Uuid, BpfdError>>,
-}
-
-#[derive(Debug)]
-pub(crate) struct LoadTracepointArgs {
-    pub(crate) location: Location,
-    pub(crate) id: Option<Uuid>,
-    pub(crate) section_name: String,
-    pub(crate) global_data: HashMap<String, Vec<u8>>,
-    pub(crate) map_owner_uuid: Option<Uuid>,
-    pub(crate) tracepoint: String,
-    pub(crate) username: String,
-    pub(crate) responder: Responder<Result<Uuid, BpfdError>>,
-}
-
-#[derive(Debug)]
-pub(crate) struct LoadKprobeArgs {
-    pub(crate) location: Location,
-    pub(crate) id: Option<Uuid>,
-    pub(crate) section_name: String,
-    pub(crate) global_data: HashMap<String, Vec<u8>>,
-    pub(crate) map_owner_uuid: Option<Uuid>,
-    pub(crate) fn_name: String,
-    pub(crate) offset: u64,
-    pub(crate) retprobe: bool,
-    pub(crate) _namespace: Option<String>,
-    pub(crate) username: String,
-    pub(crate) responder: Responder<Result<Uuid, BpfdError>>,
-}
-
-#[derive(Debug)]
-pub(crate) struct LoadUprobeArgs {
-    pub(crate) location: Location,
-    pub(crate) id: Option<Uuid>,
-    pub(crate) section_name: String,
-    pub(crate) global_data: HashMap<String, Vec<u8>>,
-    pub(crate) map_owner_uuid: Option<Uuid>,
-    pub(crate) fn_name: Option<String>,
-    pub(crate) offset: u64,
-    pub(crate) target: String,
-    pub(crate) retprobe: bool,
-    pub(crate) pid: Option<i32>,
-    pub(crate) _namespace: Option<String>,
-    pub(crate) username: String,
-    pub(crate) responder: Responder<Result<Uuid, BpfdError>>,
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) enum Program {
+    Xdp(XdpProgram),
+    Tc(TcProgram),
+    Tracepoint(TracepointProgram),
+    Kprobe(KprobeProgram),
+    Uprobe(UprobeProgram),
+    Unsupported(KernelProgramInfo),
 }
 
 #[derive(Debug)]
 pub(crate) struct UnloadArgs {
     pub(crate) id: Uuid,
-    pub(crate) username: String,
     pub(crate) responder: Responder<Result<(), BpfdError>>,
 }
 
@@ -213,7 +152,10 @@ impl TryFrom<AyaProgInfo> for KernelProgramInfo {
     fn try_from(prog: AyaProgInfo) -> Result<Self, Self::Error> {
         Ok(KernelProgramInfo {
             id: prog.id(),
-            name: prog.name_as_str().unwrap().to_string(),
+            name: prog
+                .name_as_str()
+                .expect("Program name is not valid unicode")
+                .to_string(),
             program_type: prog.program_type(),
             loaded_at: DateTime::<Local>::from(prog.loaded_at())
                 .format("%Y-%m-%dT%H:%M:%S%z")
@@ -231,177 +173,85 @@ impl TryFrom<AyaProgInfo> for KernelProgramInfo {
     }
 }
 
-/// ProgramInfo stores information about bpf programs loaded on a system
-/// which are managed via bpfd.
-#[derive(Debug, Clone)]
-pub(crate) struct ProgramInfo {
-    pub(crate) id: Option<Uuid>,
-    pub(crate) name: Option<String>,
-    pub(crate) program_type: Option<u32>,
-    pub(crate) location: Option<Location>,
-    pub(crate) global_data: Option<HashMap<String, Vec<u8>>>,
-    pub(crate) map_pin_path: Option<String>,
-    pub(crate) map_used_by: Option<Vec<Uuid>>,
-    pub(crate) map_owner_uuid: Option<Uuid>,
-    pub(crate) attach_info: Option<AttachInfo>,
-    pub(crate) kernel_info: KernelProgramInfo,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) enum AttachInfo {
-    Xdp(XdpAttachInfo),
-    Tc(TcAttachInfo),
-    Tracepoint(TracepointAttachInfo),
-    Kprobe(KprobeAttachInfo),
-    Uprobe(UprobeAttachInfo),
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub(crate) struct XdpAttachInfo {
-    pub(crate) priority: i32,
-    pub(crate) iface: String,
-    pub(crate) position: i32,
-    pub(crate) proceed_on: XdpProceedOn,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub(crate) struct TcAttachInfo {
-    pub(crate) priority: i32,
-    pub(crate) iface: String,
-    pub(crate) position: i32,
-    pub(crate) proceed_on: TcProceedOn,
-    pub(crate) direction: Direction,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub(crate) struct TracepointAttachInfo {
-    pub(crate) tracepoint: String,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub(crate) struct KprobeAttachInfo {
-    pub(crate) fn_name: String,
-    pub(crate) offset: u64,
-    pub(crate) retprobe: bool,
-    pub(crate) namespace: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub(crate) struct UprobeAttachInfo {
-    pub(crate) fn_name: Option<String>,
-    pub(crate) offset: u64,
-    pub(crate) target: String,
-    pub(crate) retprobe: bool,
-    pub(crate) pid: Option<i32>,
-    pub(crate) namespace: Option<String>,
-}
-
-#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Clone)]
-pub(crate) struct Metadata {
-    pub(crate) priority: i32,
-    pub(crate) attached: bool,
-}
-
-impl Metadata {
-    pub(crate) fn new(priority: i32) -> Self {
-        Metadata {
-            priority,
-            attached: false,
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) enum Program {
-    Xdp(XdpProgram),
-    Tracepoint(TracepointProgram),
-    Tc(TcProgram),
-    Kprobe(KprobeProgram),
-    Uprobe(UprobeProgram),
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct XdpProgram {
-    pub(crate) data: ProgramData,
-    pub(crate) info: XdpProgramInfo,
-}
-
-impl XdpProgram {
-    pub(crate) fn new(data: ProgramData, info: XdpProgramInfo) -> Self {
-        Self { data, info }
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct TcProgram {
-    pub(crate) data: ProgramData,
-    pub(crate) info: TcProgramInfo,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct TracepointProgram {
-    pub(crate) data: ProgramData,
-    pub(crate) info: TracepointProgramInfo,
-}
-
-impl TracepointProgram {
-    pub(crate) fn new(data: ProgramData, info: TracepointProgramInfo) -> Self {
-        Self { data, info }
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct KprobeProgram {
-    pub(crate) data: ProgramData,
-    pub(crate) info: KprobeProgramInfo,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct UprobeProgram {
-    pub(crate) data: ProgramData,
-    pub(crate) info: UprobeProgramInfo,
-}
-
-impl KprobeProgram {
-    pub(crate) fn _new(data: ProgramData, info: KprobeProgramInfo) -> Self {
-        Self { data, info }
-    }
-}
-
-impl UprobeProgram {
-    pub(crate) fn _new(data: ProgramData, info: UprobeProgramInfo) -> Self {
-        Self { data, info }
-    }
-}
-
-// ProgramData represents all of the core information needed to load
-// a program reguardless of ProgramType.
-#[derive(Serialize, Deserialize, Clone)]
+/// ProgramInfo stores information about bpf programs that are loaded and managed
+/// by bpfd.
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct ProgramData {
-    pub(crate) location: Location,
-    pub(crate) section_name: String,
-    pub(crate) global_data: HashMap<String, Vec<u8>>,
-    pub(crate) owner: String,
-    pub(crate) map_owner_uuid: Option<Uuid>,
-    pub(crate) kernel_info: Option<KernelProgramInfo>,
+    // known at load time, set by user
+    name: String,
+    location: Location,
+    id: Option<Uuid>,
+    global_data: HashMap<String, Vec<u8>>,
+    map_owner_id: Option<Uuid>,
+
+    // populated after load
+    kernel_info: Option<KernelProgramInfo>,
+    map_pin_path: Option<PathBuf>,
+    maps_used_by: Option<Vec<Uuid>>,
 }
 
 impl ProgramData {
     pub(crate) fn new(
         location: Location,
-        section_name: String,
+        name: String,
+        id: Option<Uuid>,
         global_data: HashMap<String, Vec<u8>>,
-        map_owner_uuid: Option<Uuid>,
-        owner: String,
+        map_owner_id: Option<Uuid>,
     ) -> Self {
         Self {
+            name,
             location,
-            section_name,
-            owner,
+            id,
             global_data,
-            map_owner_uuid,
+            map_owner_id,
             kernel_info: None,
+            map_pin_path: None,
+            maps_used_by: None,
         }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn id(&self) -> Option<Uuid> {
+        self.id
+    }
+
+    pub(crate) fn set_id(&mut self, id: Option<Uuid>) {
+        self.id = id
+    }
+
+    pub(crate) fn set_kernel_info(&mut self, info: Option<KernelProgramInfo>) {
+        self.kernel_info = info
+    }
+
+    pub(crate) fn kernel_info(&self) -> Option<&KernelProgramInfo> {
+        self.kernel_info.as_ref()
+    }
+
+    pub(crate) fn global_data(&self) -> &HashMap<String, Vec<u8>> {
+        &self.global_data
+    }
+
+    pub(crate) fn set_map_pin_path(&mut self, path: Option<PathBuf>) {
+        self.map_pin_path = path
+    }
+
+    pub(crate) fn map_pin_path(&self) -> Option<&Path> {
+        self.map_pin_path.as_deref()
+    }
+
+    pub(crate) fn map_owner_id(&self) -> Option<Uuid> {
+        self.map_owner_id
+    }
+
+    pub(crate) fn set_maps_used_by(&mut self, used_by: Option<Vec<Uuid>>) {
+        self.maps_used_by = used_by
+    }
+
+    pub(crate) fn maps_used_by(&self) -> Option<&Vec<Uuid>> {
+        self.maps_used_by.as_ref()
     }
 
     pub(crate) async fn program_bytes(&mut self) -> Result<Vec<u8>, BpfdError> {
@@ -410,17 +260,17 @@ impl ProgramData {
             Ok((v, s)) => {
                 match self.location {
                     Location::Image(_) => {
-                        // If section name isn't provided and we're loading from a container
-                        // image use the section name provided in the image metadata, otherwise
-                        // always use the provided section name.
-                        let provided_sec_name = self.section_name.clone();
+                        // If program name isn't provided and we're loading from a container
+                        // image use the program name provided in the image metadata, otherwise
+                        // always use the provided program name.
+                        let provided_name = self.name.clone();
 
-                        if provided_sec_name.is_empty() {
-                            self.section_name = s;
-                        } else if s != provided_sec_name {
+                        if provided_name.is_empty() {
+                            self.name = s;
+                        } else if s != provided_name {
                             return Err(BpfdError::BytecodeMetaDataMismatch {
-                                image_sec_name: s,
-                                provided_sec_name,
+                                image_prog_name: s,
+                                provided_prog_name: provided_name,
                             });
                         }
                     }
@@ -432,48 +282,148 @@ impl ProgramData {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct XdpProgramInfo {
-    pub(crate) if_name: String,
-    pub(crate) if_index: u32,
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct XdpProgram {
+    pub(crate) data: ProgramData,
+    // known at load time
+    pub(crate) priority: i32,
+    pub(crate) iface: String,
+    pub(crate) proceed_on: XdpProceedOn,
+    // populated after load
     #[serde(skip)]
     pub(crate) current_position: Option<usize>,
-    pub(crate) metadata: Metadata,
-    pub(crate) proceed_on: XdpProceedOn,
+    pub(crate) if_index: Option<u32>,
+    pub(crate) attached: bool,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct TcProgramInfo {
-    pub(crate) if_name: String,
-    pub(crate) if_index: u32,
-    #[serde(skip)]
-    pub(crate) current_position: Option<usize>,
-    pub(crate) metadata: Metadata,
+impl XdpProgram {
+    pub(crate) fn new(
+        data: ProgramData,
+        priority: i32,
+        iface: String,
+        proceed_on: XdpProceedOn,
+    ) -> Self {
+        Self {
+            data,
+            priority,
+            iface,
+            proceed_on,
+            current_position: None,
+            if_index: None,
+            attached: false,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct TcProgram {
+    pub(crate) data: ProgramData,
+    // known at load time
+    pub(crate) priority: i32,
+    pub(crate) iface: String,
     pub(crate) proceed_on: TcProceedOn,
     pub(crate) direction: Direction,
+    // populated after load
+    #[serde(skip)]
+    pub(crate) current_position: Option<usize>,
+    pub(crate) if_index: Option<u32>,
+    pub(crate) attached: bool,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct TracepointProgramInfo {
+impl TcProgram {
+    pub(crate) fn new(
+        data: ProgramData,
+        priority: i32,
+        iface: String,
+        proceed_on: TcProceedOn,
+        direction: Direction,
+    ) -> Self {
+        Self {
+            data,
+            priority,
+            iface,
+            proceed_on,
+            direction,
+            current_position: None,
+            if_index: None,
+            attached: false,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct TracepointProgram {
+    pub(crate) data: ProgramData,
+    // known at load time
     pub(crate) tracepoint: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct KprobeProgramInfo {
+impl TracepointProgram {
+    pub(crate) fn new(data: ProgramData, tracepoint: String) -> Self {
+        Self { data, tracepoint }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct KprobeProgram {
+    pub(crate) data: ProgramData,
+    // Known at load time
     pub(crate) fn_name: String,
     pub(crate) offset: u64,
     pub(crate) retprobe: bool,
     pub(crate) namespace: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct UprobeProgramInfo {
+impl KprobeProgram {
+    pub(crate) fn new(
+        data: ProgramData,
+        fn_name: String,
+        offset: u64,
+        retprobe: bool,
+        namespace: Option<String>,
+    ) -> Self {
+        Self {
+            data,
+            fn_name,
+            offset,
+            retprobe,
+            namespace,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct UprobeProgram {
+    pub(crate) data: ProgramData,
+    // Known at load time
     pub(crate) fn_name: Option<String>,
     pub(crate) offset: u64,
     pub(crate) target: String,
     pub(crate) retprobe: bool,
     pub(crate) pid: Option<i32>,
     pub(crate) namespace: Option<String>,
+}
+
+impl UprobeProgram {
+    pub(crate) fn new(
+        data: ProgramData,
+        fn_name: Option<String>,
+        offset: u64,
+        target: String,
+        retprobe: bool,
+        pid: Option<i32>,
+        namespace: Option<String>,
+    ) -> Self {
+        Self {
+            data,
+            fn_name,
+            offset,
+            target,
+            retprobe,
+            pid,
+            namespace,
+        }
+    }
 }
 
 impl Program {
@@ -484,115 +434,111 @@ impl Program {
             Program::Tracepoint(_) => ProgramType::Tracepoint,
             Program::Kprobe(_) => ProgramType::Probe,
             Program::Uprobe(_) => ProgramType::Probe,
+            Program::Unsupported(i) => i.program_type.try_into().unwrap(),
         }
     }
 
     pub(crate) fn dispatcher_id(&self) -> Option<DispatcherId> {
         match self {
-            Program::Xdp(p) => Some(DispatcherId::Xdp(DispatcherInfo(p.info.if_index, None))),
+            Program::Xdp(p) => Some(DispatcherId::Xdp(DispatcherInfo(
+                p.if_index.expect("if_index should be known at this point"),
+                None,
+            ))),
             Program::Tc(p) => Some(DispatcherId::Tc(DispatcherInfo(
-                p.info.if_index,
-                Some(p.info.direction),
+                p.if_index.expect("if_index should be known at this point"),
+                Some(p.direction),
             ))),
             _ => None,
         }
     }
 
-    pub(crate) fn data_mut(&mut self) -> &mut ProgramData {
+    pub(crate) fn data_mut(&mut self) -> Result<&mut ProgramData, BpfdError> {
         match self {
-            Program::Xdp(p) => &mut p.data,
-            Program::Tracepoint(p) => &mut p.data,
-            Program::Tc(p) => &mut p.data,
-            Program::Kprobe(p) => &mut p.data,
-            Program::Uprobe(p) => &mut p.data,
+            Program::Xdp(p) => Ok(&mut p.data),
+            Program::Tracepoint(p) => Ok(&mut p.data),
+            Program::Tc(p) => Ok(&mut p.data),
+            Program::Kprobe(p) => Ok(&mut p.data),
+            Program::Uprobe(p) => Ok(&mut p.data),
+            Program::Unsupported(_) => Err(BpfdError::Error(
+                "Unsupported program type has no ProgramData".to_string(),
+            )),
         }
     }
 
-    pub(crate) fn data(&self) -> &ProgramData {
+    pub(crate) fn data(&self) -> Result<&ProgramData, BpfdError> {
         match self {
-            Program::Xdp(p) => &p.data,
-            Program::Tracepoint(p) => &p.data,
-            Program::Tc(p) => &p.data,
-            Program::Kprobe(p) => &p.data,
-            Program::Uprobe(p) => &p.data,
+            Program::Xdp(p) => Ok(&p.data),
+            Program::Tracepoint(p) => Ok(&p.data),
+            Program::Tc(p) => Ok(&p.data),
+            Program::Kprobe(p) => Ok(&p.data),
+            Program::Uprobe(p) => Ok(&p.data),
+            Program::Unsupported(_) => Err(BpfdError::Error(
+                "Unsupported program type has no ProgramData".to_string(),
+            )),
         }
     }
 
-    pub(crate) fn metadata(&self) -> Option<&Metadata> {
+    pub(crate) fn attached(&self) -> Option<bool> {
         match self {
-            Program::Xdp(p) => Some(&p.info.metadata),
-            Program::Tracepoint(_) => None,
-            Program::Tc(p) => Some(&p.info.metadata),
-            Program::Kprobe(_) => None,
-            Program::Uprobe(_) => None,
-        }
-    }
-
-    pub(crate) fn owner(&self) -> &String {
-        match self {
-            Program::Xdp(p) => &p.data.owner,
-            Program::Tracepoint(p) => &p.data.owner,
-            Program::Tc(p) => &p.data.owner,
-            Program::Kprobe(p) => &p.data.owner,
-            Program::Uprobe(p) => &p.data.owner,
+            Program::Xdp(p) => Some(p.attached),
+            Program::Tc(p) => Some(p.attached),
+            _ => None,
         }
     }
 
     pub(crate) fn set_attached(&mut self) {
         match self {
-            Program::Xdp(p) => p.info.metadata.attached = true,
-            Program::Tc(p) => p.info.metadata.attached = true,
-            Program::Tracepoint(_) => (),
-            Program::Kprobe(_) => (),
-            Program::Uprobe(_) => (),
+            Program::Xdp(p) => p.attached = true,
+            Program::Tc(p) => p.attached = true,
+            _ => (),
         }
     }
 
     pub(crate) fn set_position(&mut self, pos: Option<usize>) {
         match self {
-            Program::Xdp(p) => p.info.current_position = pos,
-            Program::Tc(p) => p.info.current_position = pos,
-            Program::Tracepoint(_) => (),
-            Program::Kprobe(_) => (),
-            Program::Uprobe(_) => (),
+            Program::Xdp(p) => p.current_position = pos,
+            Program::Tc(p) => p.current_position = pos,
+            _ => (),
         }
     }
 
-    pub(crate) fn set_kernel_info(&mut self, info: KernelProgramInfo) {
+    pub(crate) fn kernel_info(&self) -> Option<&KernelProgramInfo> {
         match self {
-            Program::Xdp(p) => p.data.kernel_info = Some(info),
-            Program::Tc(p) => p.data.kernel_info = Some(info),
-            Program::Tracepoint(p) => p.data.kernel_info = Some(info),
-            Program::Kprobe(p) => p.data.kernel_info = Some(info),
-            Program::Uprobe(p) => p.data.kernel_info = Some(info),
+            Program::Xdp(p) => p.data.kernel_info.as_ref(),
+            Program::Tc(p) => p.data.kernel_info.as_ref(),
+            Program::Tracepoint(p) => p.data.kernel_info.as_ref(),
+            Program::Kprobe(p) => p.data.kernel_info.as_ref(),
+            Program::Uprobe(p) => p.data.kernel_info.as_ref(),
+            // KernelProgramInfo will never be nil for Unsupported programs
+            Program::Unsupported(p) => Some(p),
         }
     }
 
-    pub(crate) fn save(&self, uuid: Uuid) -> Result<(), anyhow::Error> {
-        let path = format!("{RTDIR_PROGRAMS}/{uuid}");
+    pub(crate) fn save(&self, id: Uuid) -> Result<(), anyhow::Error> {
+        let path = format!("{RTDIR_PROGRAMS}/{id}");
         serde_json::to_writer(&fs::File::create(path)?, &self)?;
         Ok(())
     }
 
-    pub(crate) fn delete(&self, uuid: Uuid) -> Result<(), anyhow::Error> {
-        let path = format!("{RTDIR_PROGRAMS}/{uuid}");
+    pub(crate) fn delete(&self, id: Uuid) -> Result<(), anyhow::Error> {
+        let path = format!("{RTDIR_PROGRAMS}/{id}");
         if PathBuf::from(&path).exists() {
             fs::remove_file(path)?;
         }
 
-        let path = format!("{RTDIR_FS}/prog_{uuid}");
+        let path = format!("{RTDIR_FS}/prog_{id}");
         if PathBuf::from(&path).exists() {
             fs::remove_file(path)?;
         }
-        let path = format!("{RTDIR_FS}/prog_{uuid}_link");
+        let path = format!("{RTDIR_FS}/prog_{id}_link");
         if PathBuf::from(&path).exists() {
             fs::remove_file(path)?;
         }
         Ok(())
     }
 
-    pub(crate) fn load(uuid: Uuid) -> Result<Self, anyhow::Error> {
-        let path = format!("{RTDIR_PROGRAMS}/{uuid}");
+    pub(crate) fn load(id: Uuid) -> Result<Self, anyhow::Error> {
+        let path = format!("{RTDIR_PROGRAMS}/{id}");
         let file = fs::File::open(path)?;
         let reader = BufReader::new(file);
         let prog = serde_json::from_reader(reader)?;
@@ -601,37 +547,71 @@ impl Program {
 
     pub(crate) fn if_index(&self) -> Option<u32> {
         match self {
-            Program::Xdp(p) => Some(p.info.if_index),
-            Program::Tracepoint(_) => None,
-            Program::Tc(p) => Some(p.info.if_index),
-            Program::Kprobe(_) => None,
-            Program::Uprobe(_) => None,
+            Program::Xdp(p) => p.if_index,
+            Program::Tc(p) => p.if_index,
+            _ => None,
+        }
+    }
+
+    pub(crate) fn set_if_index(&mut self, if_index: u32) {
+        match self {
+            Program::Xdp(p) => p.if_index = Some(if_index),
+            Program::Tc(p) => p.if_index = Some(if_index),
+            _ => (),
         }
     }
 
     pub(crate) fn if_name(&self) -> Option<String> {
         match self {
-            Program::Xdp(p) => Some(p.info.if_name.clone()),
-            Program::Tracepoint(_) => None,
-            Program::Tc(p) => Some(p.info.if_name.clone()),
-            Program::Kprobe(_) => None,
-            Program::Uprobe(_) => None,
+            Program::Xdp(p) => Some(p.iface.clone()),
+            Program::Tc(p) => Some(p.iface.clone()),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn priority(&self) -> Option<i32> {
+        match self {
+            Program::Xdp(p) => Some(p.priority),
+            Program::Tc(p) => Some(p.priority),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn location(&self) -> Option<&Location> {
+        match self {
+            Program::Xdp(p) => Some(&p.data.location),
+            Program::Tracepoint(p) => Some(&p.data.location),
+            Program::Tc(p) => Some(&p.data.location),
+            Program::Kprobe(p) => Some(&p.data.location),
+            Program::Uprobe(p) => Some(&p.data.location),
+            Program::Unsupported(_) => None,
         }
     }
 
     pub(crate) fn direction(&self) -> Option<Direction> {
         match self {
-            Program::Xdp(_) => None,
-            Program::Tracepoint(_) => None,
-            Program::Tc(p) => Some(p.info.direction),
-            Program::Kprobe(_) => None,
-            Program::Uprobe(_) => None,
+            Program::Tc(p) => Some(p.direction),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Program::Xdp(p) => &p.data.name,
+            Program::Tracepoint(p) => &p.data.name,
+            Program::Tc(p) => &p.data.name,
+            Program::Kprobe(p) => &p.data.name,
+            Program::Uprobe(p) => &p.data.name,
+            Program::Unsupported(k) => &k.name,
         }
     }
 }
 
+// BpfMap represents a single map pin path used by a Program.  It has to be a
+// separate object becuase it's lifetime is slightly different from a Program.
+// More specifically a BpfMap can outlive a Program if other Programs are using
+// it.
 #[derive(Debug, Clone)]
 pub(crate) struct BpfMap {
-    pub(crate) map_pin_path: String,
     pub(crate) used_by: Vec<Uuid>,
 }

--- a/bpfd/src/errors.rs
+++ b/bpfd/src/errors.rs
@@ -16,10 +16,6 @@ pub enum BpfdError {
     SectionNameNotValid(String),
     #[error("No room to attach program. Please remove one and try again.")]
     TooManyPrograms,
-    #[error("Invalid ID")]
-    InvalidID,
-    #[error("Not authorized")]
-    NotAuthorized,
     #[error("Invalid Interface")]
     InvalidInterface,
     #[error("Failed to pin link {0}")]
@@ -34,10 +30,10 @@ pub enum BpfdError {
     DispatcherNotRequired,
     #[error(transparent)]
     BpfBytecodeError(#[from] anyhow::Error),
-    #[error("Bytecode image has section name: {image_sec_name} isn't equal to the provided section name {provided_sec_name}")]
+    #[error("Bytecode image has section name: {image_prog_name} isn't equal to the provided section name {provided_prog_name}")]
     BytecodeMetaDataMismatch {
-        image_sec_name: String,
-        provided_sec_name: String,
+        image_prog_name: String,
+        provided_prog_name: String,
     },
     #[error("Unable to parse passed UUID {0}")]
     PassedUUIDError(#[from] uuid::Error),

--- a/bpfd/src/multiprog/tc.rs
+++ b/bpfd/src/multiprog/tc.rs
@@ -66,7 +66,7 @@ impl TcDispatcher {
             .collect();
         let mut chain_call_actions = [0; 10];
         for (_, v) in extensions.iter() {
-            chain_call_actions[v.info.current_position.unwrap()] = v.info.proceed_on.mask()
+            chain_call_actions[v.current_position.unwrap()] = v.proceed_on.mask()
         }
 
         let config = TcDispatcherConfig {
@@ -177,10 +177,10 @@ impl TcDispatcher {
             .unwrap()
             .try_into()?;
 
-        extensions.sort_by(|(_, a), (_, b)| a.info.current_position.cmp(&b.info.current_position));
+        extensions.sort_by(|(_, a), (_, b)| a.current_position.cmp(&b.current_position));
 
         for (i, (k, v)) in extensions.iter_mut().enumerate() {
-            if v.info.metadata.attached {
+            if v.attached {
                 let mut ext = Extension::from_pin(format!("{RTDIR_FS}/prog_{k}"))?;
                 let target_fn = format!("prog{i}");
                 let new_link_id = ext
@@ -195,29 +195,33 @@ impl TcDispatcher {
                 new_link.pin(path).map_err(BpfdError::UnableToPinLink)?;
             } else {
                 let program_bytes = v.data.program_bytes().await?;
+                let name = v.data.name();
+                let global_data = v.data.global_data();
+
                 let mut bpf = BpfLoader::new();
 
-                for (name, value) in &v.data.global_data {
+                for (name, value) in global_data {
                     bpf.set_global(name, value.as_slice(), true);
                 }
 
-                let (_, map_pin_path) = calc_map_pin_path(**k, v.data.map_owner_uuid);
+                let (_, map_pin_path) = calc_map_pin_path(**k, v.data.map_owner_id());
                 let mut bpf = bpf
                     .allow_unsupported_maps()
                     .map_pin_path(map_pin_path.clone())
-                    .extension(&v.data.section_name)
+                    .extension(name)
                     .load(&program_bytes)
                     .map_err(BpfdError::BpfLoadError)?;
 
                 let ext: &mut Extension = bpf
-                    .program_mut(&v.data.section_name.clone())
-                    .ok_or_else(|| BpfdError::SectionNameNotValid(v.data.section_name.clone()))?
+                    .program_mut(name)
+                    .ok_or_else(|| BpfdError::SectionNameNotValid(name.to_string()))?
                     .try_into()?;
 
                 let target_fn = format!("prog{i}");
 
                 ext.load(dispatcher.fd()?.try_clone()?, &target_fn)?;
-                v.data.kernel_info = Some(ext.program_info()?.try_into()?);
+                v.data
+                    .set_kernel_info(Some(ext.program_info()?.try_into()?));
 
                 ext.pin(format!("{RTDIR_FS}/prog_{k}"))
                     .map_err(BpfdError::UnableToPinProgram)?;

--- a/bpfd/src/oci_utils/image_manager.rs
+++ b/bpfd/src/oci_utils/image_manager.rs
@@ -64,8 +64,8 @@ impl BytecodeImage {
         &self.image_url
     }
 
-    pub(crate) fn get_pull_policy(self) -> ImagePullPolicy {
-        self.image_pull_policy
+    pub(crate) fn get_pull_policy(&self) -> &ImagePullPolicy {
+        &self.image_pull_policy
     }
 
     pub(crate) async fn get_image(

--- a/bpfd/src/rpc.rs
+++ b/bpfd/src/rpc.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 // Copyright Authors of bpfd
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use bpfd_api::{
     v1::{
@@ -8,29 +11,20 @@ use bpfd_api::{
         load_request,
         load_request_common::Location,
         loader_server::Loader,
-        KprobeAttachInfo, ListRequest, ListResponse, LoadRequest, LoadResponse, NoAttachInfo,
-        NoLocation, PullBytecodeRequest, PullBytecodeResponse, TcAttachInfo, TracepointAttachInfo,
+        KprobeAttachInfo, ListRequest, ListResponse, LoadRequest, LoadResponse,
+        PullBytecodeRequest, PullBytecodeResponse, TcAttachInfo, TracepointAttachInfo,
         UnloadRequest, UnloadResponse, UprobeAttachInfo, XdpAttachInfo,
     },
     TcProceedOn, XdpProceedOn,
 };
-use log::{debug, warn};
+use log::warn;
 use tokio::sync::{mpsc, mpsc::Sender, oneshot};
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
 use crate::command::{
-    Command, LoadKprobeArgs, LoadTCArgs, LoadTracepointArgs, LoadUprobeArgs, LoadXDPArgs,
-    PullBytecodeArgs, UnloadArgs,
-};
-
-#[derive(Debug, Default)]
-struct User {
-    username: String,
-}
-
-static DEFAULT_USER: User = User {
-    username: String::new(),
+    Command, KprobeProgram, LoadArgs, Program, ProgramData, PullBytecodeArgs, TcProgram,
+    TracepointProgram, UnloadArgs, UprobeProgram, XdpProgram,
 };
 
 #[derive(Debug)]
@@ -48,13 +42,6 @@ impl BpfdLoader {
 #[tonic::async_trait]
 impl Loader for BpfdLoader {
     async fn load(&self, request: Request<LoadRequest>) -> Result<Response<LoadResponse>, Status> {
-        let mut reply = LoadResponse { id: String::new() };
-        let username = request
-            .extensions()
-            .get::<User>()
-            .unwrap_or(&DEFAULT_USER)
-            .username
-            .to_string();
         let request = request.into_inner();
 
         let (resp_tx, resp_rx) = oneshot::channel();
@@ -88,97 +75,72 @@ impl Loader for BpfdLoader {
             )
         };
 
-        let cmd = match request.attach_info.unwrap() {
-            load_request::AttachInfo::XdpAttachInfo(attach) => Command::LoadXDP(LoadXDPArgs {
-                responder: resp_tx,
-                id,
-                global_data: common.global_data,
-                map_owner_uuid,
-                location: bytecode_source,
-                iface: attach.iface,
-                priority: attach.priority,
-                proceed_on: XdpProceedOn::from_int32s(attach.proceed_on)
-                    .map_err(|_| Status::aborted("failed to parse proceed_on"))?,
-                section_name: common.section_name,
-                username,
-            }),
-            load_request::AttachInfo::TcAttachInfo(attach) => {
-                let direction = attach
-                    .direction
-                    .try_into()
-                    .map_err(|_| Status::aborted("direction is not a string"))?;
-                Command::LoadTC(LoadTCArgs {
-                    responder: resp_tx,
-                    location: bytecode_source,
-                    id,
-                    global_data: common.global_data,
-                    map_owner_uuid,
-                    iface: attach.iface,
-                    priority: attach.priority,
-                    direction,
-                    proceed_on: TcProceedOn::from_int32s(attach.proceed_on)
+        let data = ProgramData::new(
+            bytecode_source,
+            common.section_name,
+            id,
+            common.global_data,
+            map_owner_uuid,
+        );
+
+        let load_args = LoadArgs {
+            program: match request.attach_info.unwrap() {
+                load_request::AttachInfo::XdpAttachInfo(attach) => Program::Xdp(XdpProgram::new(
+                    data,
+                    attach.priority,
+                    attach.iface,
+                    XdpProceedOn::from_int32s(attach.proceed_on)
                         .map_err(|_| Status::aborted("failed to parse proceed_on"))?,
-                    section_name: common.section_name,
-                    username,
-                })
-            }
-            load_request::AttachInfo::TracepointAttachInfo(attach) => {
-                Command::LoadTracepoint(LoadTracepointArgs {
-                    responder: resp_tx,
-                    id,
-                    global_data: common.global_data,
-                    map_owner_uuid,
-                    location: bytecode_source,
-                    tracepoint: attach.tracepoint,
-                    section_name: common.section_name,
-                    username,
-                })
-            }
-            load_request::AttachInfo::KprobeAttachInfo(attach) => {
-                Command::LoadKprobe(LoadKprobeArgs {
-                    responder: resp_tx,
-                    id,
-                    global_data: common.global_data,
-                    map_owner_uuid,
-                    location: bytecode_source,
-                    fn_name: attach.fn_name,
-                    offset: attach.offset,
-                    retprobe: attach.retprobe,
-                    _namespace: attach.namespace,
-                    section_name: common.section_name,
-                    username,
-                })
-            }
-            load_request::AttachInfo::UprobeAttachInfo(attach) => {
-                Command::LoadUprobe(LoadUprobeArgs {
-                    responder: resp_tx,
-                    id,
-                    global_data: common.global_data,
-                    map_owner_uuid,
-                    location: bytecode_source,
-                    fn_name: attach.fn_name,
-                    offset: attach.offset,
-                    target: attach.target,
-                    retprobe: attach.retprobe,
-                    pid: attach.pid,
-                    _namespace: attach.namespace,
-                    section_name: common.section_name,
-                    username,
-                })
-            }
+                )),
+                load_request::AttachInfo::TcAttachInfo(attach) => {
+                    let direction = attach
+                        .direction
+                        .try_into()
+                        .map_err(|_| Status::aborted("direction is not a string"))?;
+                    Program::Tc(TcProgram::new(
+                        data,
+                        attach.priority,
+                        attach.iface,
+                        TcProceedOn::from_int32s(attach.proceed_on)
+                            .map_err(|_| Status::aborted("failed to parse proceed_on"))?,
+                        direction,
+                    ))
+                }
+                load_request::AttachInfo::TracepointAttachInfo(attach) => {
+                    Program::Tracepoint(TracepointProgram::new(data, attach.tracepoint))
+                }
+                load_request::AttachInfo::KprobeAttachInfo(attach) => {
+                    Program::Kprobe(KprobeProgram::new(
+                        data,
+                        attach.fn_name,
+                        attach.offset,
+                        attach.retprobe,
+                        attach.namespace,
+                    ))
+                }
+                load_request::AttachInfo::UprobeAttachInfo(attach) => {
+                    Program::Uprobe(UprobeProgram::new(
+                        data,
+                        attach.fn_name,
+                        attach.offset,
+                        attach.target,
+                        attach.retprobe,
+                        attach.pid,
+                        attach.namespace,
+                    ))
+                }
+            },
+            responder: resp_tx,
         };
 
         let tx = self.tx.lock().unwrap().clone();
         // Send the GET request
-        tx.send(cmd).await.unwrap();
+        tx.send(Command::Load(load_args)).await.unwrap();
 
         // Await the response
         match resp_rx.await {
             Ok(res) => match res {
-                Ok(id) => {
-                    reply.id = id.to_string();
-                    Ok(Response::new(reply))
-                }
+                Ok(id) => Ok(Response::new(LoadResponse { id: id.to_string() })),
                 Err(e) => {
                     warn!("BPFD load error: {:#?}", e);
                     Err(Status::aborted(format!("{e}")))
@@ -197,12 +159,6 @@ impl Loader for BpfdLoader {
         request: Request<UnloadRequest>,
     ) -> Result<Response<UnloadResponse>, Status> {
         let reply = UnloadResponse {};
-        let username = request
-            .extensions()
-            .get::<User>()
-            .unwrap_or(&DEFAULT_USER)
-            .username
-            .to_string();
         let request = request.into_inner();
         let id = request
             .id
@@ -212,7 +168,6 @@ impl Loader for BpfdLoader {
         let (resp_tx, resp_rx) = oneshot::channel();
         let cmd = Command::Unload(UnloadArgs {
             id,
-            username,
             responder: resp_tx,
         });
 
@@ -251,20 +206,7 @@ impl Loader for BpfdLoader {
             Ok(res) => match res {
                 Ok(results) => {
                     for r in results {
-                        let loc;
-                        let attach_info;
-                        let name;
-                        // With bpfd "multi-attach" programs are loaded as
-                        // extensions to a dispatcher. The kernel see's these
-                        // programs as type "BPF_PROG_TYPE_EXT" rather than
-                        // their actual type.  Therefore we check here if the
-                        // program is owned by bpfd and use our stored "real"
-                        // type for the filtering. Otherwise we use what's stored
-                        // in the kernel.
-                        let program_type = match r.program_type {
-                            Some(t) => t,
-                            None => r.kernel_info.program_type,
-                        };
+                        let program_type = r.kind() as u32;
 
                         // initial prog type filtering
                         if let Some(p) = request.get_ref().program_type {
@@ -273,130 +215,135 @@ impl Loader for BpfdLoader {
                             }
                         }
 
-                        // If there's a bpfd ID we know the program has an
-                        // attach info and location
-                        let id = match r.id {
-                            Some(i) => {
-                                // populate bpfd attach info
-                                attach_info = match r
-                                    .attach_info
-                                    .expect("program should have attach info")
-                                {
-                                    crate::command::AttachInfo::Xdp(info) => {
-                                        Some(AttachInfo::XdpAttachInfo(XdpAttachInfo {
-                                            priority: info.priority,
-                                            iface: info.iface,
-                                            position: info.position,
-                                            proceed_on: info.proceed_on.as_action_vec(),
-                                        }))
-                                    }
-                                    crate::command::AttachInfo::Tc(info) => {
-                                        Some(AttachInfo::TcAttachInfo(TcAttachInfo {
-                                            priority: info.priority,
-                                            iface: info.iface,
-                                            position: info.position,
-                                            direction: info.direction.to_string(),
-                                            proceed_on: info.proceed_on.as_action_vec(),
-                                        }))
-                                    }
-                                    crate::command::AttachInfo::Tracepoint(info) => Some(
-                                        AttachInfo::TracepointAttachInfo(TracepointAttachInfo {
-                                            tracepoint: info.tracepoint,
-                                        }),
-                                    ),
-                                    crate::command::AttachInfo::Kprobe(info) => {
-                                        Some(AttachInfo::KprobeAttachInfo(KprobeAttachInfo {
-                                            fn_name: info.fn_name,
-                                            offset: info.offset,
-                                            retprobe: info.retprobe,
-                                            namespace: info.namespace,
-                                        }))
-                                    }
-                                    crate::command::AttachInfo::Uprobe(info) => {
-                                        Some(AttachInfo::UprobeAttachInfo(UprobeAttachInfo {
-                                            fn_name: info.fn_name,
-                                            offset: info.offset,
-                                            target: info.target,
-                                            retprobe: info.retprobe,
-                                            pid: info.pid,
-                                            namespace: info.namespace,
-                                        }))
-                                    }
-                                };
+                        let kernel_info = r
+                            .kernel_info()
+                            .expect("kernel info should be set for all loaded programs");
+
+                        let mut reply_entry = ListResult {
+                            id: None,
+                            name: r.name().to_owned(),
+                            attach_info: None,
+                            location: None,
+                            program_type,
+                            global_data: HashMap::new(),
+                            map_owner_uuid: String::new(),
+                            map_pin_path: String::new(),
+                            map_used_by: Vec::new(),
+                            bpf_id: kernel_info.id,
+                            loaded_at: kernel_info.loaded_at.clone(),
+                            tag: kernel_info.tag.clone(),
+                            gpl_compatible: kernel_info.gpl_compatible,
+                            map_ids: kernel_info.map_ids.clone(),
+                            btf_id: kernel_info.btf_id,
+                            bytes_xlated: kernel_info.bytes_xlated,
+                            jited: kernel_info.jited,
+                            bytes_jited: kernel_info.bytes_jited,
+                            bytes_memlock: kernel_info.bytes_memlock,
+                            verified_insns: kernel_info.verified_insns,
+                        };
+
+                        match r.data() {
+                            // program is of type Unsupported
+                            Err(_) => {
+                                if !request.get_ref().bpfd_programs_only() {
+                                    reply.results.push(reply_entry);
+                                }
+                                continue;
+                            }
+                            // Bpfd Program
+                            Ok(data) => {
+                                // populate id
+                                reply_entry.id = data.id().map(|v| v.to_string());
+
+                                reply_entry.map_pin_path = data
+                                    .map_pin_path()
+                                    .map_or(String::new(), |v| v.to_str().unwrap().to_string());
+
+                                reply_entry.map_used_by = data
+                                    .maps_used_by()
+                                    .map_or(vec![], |m| m.iter().map(|m| m.to_string()).collect());
+
+                                reply_entry.map_owner_uuid = data
+                                    .map_owner_id()
+                                    .map_or("".to_string(), |v| v.to_string());
 
                                 // populate bpfd location
-                                loc = match r.location.expect("program should have location info") {
-                                    crate::command::Location::Image(m) => {
-                                        Some(list_result::Location::Image(
-                                            bpfd_api::v1::BytecodeImage {
-                                                url: m.get_url().to_string(),
-                                                image_pull_policy: m.get_pull_policy() as i32,
-                                                // Never dump Plaintext Credentials
-                                                username: "".to_string(),
-                                                password: "".to_string(),
-                                            },
-                                        ))
-                                    }
-                                    crate::command::Location::File(m) => {
-                                        Some(list_result::Location::File(m))
+                                reply_entry.location = match r.location() {
+                                    Some(l) => match l {
+                                        crate::command::Location::Image(m) => {
+                                            Some(list_result::Location::Image(
+                                                bpfd_api::v1::BytecodeImage {
+                                                    url: m.get_url().to_string(),
+                                                    image_pull_policy: m
+                                                        .get_pull_policy()
+                                                        .to_owned()
+                                                        as i32,
+                                                    // Never dump Plaintext Credentials
+                                                    username: String::new(),
+                                                    password: String::new(),
+                                                },
+                                            ))
+                                        }
+                                        crate::command::Location::File(m) => {
+                                            Some(list_result::Location::File(m.to_string()))
+                                        }
+                                    },
+                                    None => {
+                                        // skip programs not owned by bpfd
+                                        if request.get_ref().bpfd_programs_only() {
+                                            continue;
+                                        }
+                                        None
                                     }
                                 };
 
-                                // Program names are sometimes abbreviated to a 16 byte length
-                                // by the program. If the program is owned by bpfd override the name
-                                //  with the full one stored by bpfd.
-                                name = r.name.expect("program should have a name tracked by bpfd");
-                                // return bpfd UUID
-                                Some(i.to_string())
-                            }
-                            None => {
-                                attach_info = Some(AttachInfo::None(NoAttachInfo {}));
-                                loc = Some(list_result::Location::NoLocation(NoLocation {}));
-                                name = r.kernel_info.name;
-                                // skip programs not owned by bpfd
-                                if request.get_ref().bpfd_programs_only() {
-                                    continue;
-                                }
-                                None
-                            }
-                        };
+                                reply_entry.attach_info = match r.clone() {
+                                    Program::Xdp(p) => {
+                                        Some(AttachInfo::XdpAttachInfo(XdpAttachInfo {
+                                            priority: p.priority,
+                                            iface: p.iface,
+                                            position: p.current_position.unwrap_or(0) as i32,
+                                            proceed_on: p.proceed_on.as_action_vec(),
+                                        }))
+                                    }
+                                    Program::Tc(p) => {
+                                        Some(AttachInfo::TcAttachInfo(TcAttachInfo {
+                                            priority: p.priority,
+                                            iface: p.iface,
+                                            position: p.current_position.unwrap_or(0) as i32,
+                                            direction: p.direction.to_string(),
+                                            proceed_on: p.proceed_on.as_action_vec(),
+                                        }))
+                                    }
+                                    Program::Tracepoint(p) => Some(
+                                        AttachInfo::TracepointAttachInfo(TracepointAttachInfo {
+                                            tracepoint: p.tracepoint,
+                                        }),
+                                    ),
+                                    Program::Kprobe(p) => {
+                                        Some(AttachInfo::KprobeAttachInfo(KprobeAttachInfo {
+                                            fn_name: p.fn_name,
+                                            offset: p.offset,
+                                            retprobe: p.retprobe,
+                                            namespace: p.namespace,
+                                        }))
+                                    }
+                                    Program::Uprobe(p) => {
+                                        Some(AttachInfo::UprobeAttachInfo(UprobeAttachInfo {
+                                            fn_name: p.fn_name,
+                                            offset: p.offset,
+                                            target: p.target,
+                                            retprobe: p.retprobe,
+                                            pid: p.pid,
+                                            namespace: p.namespace,
+                                        }))
+                                    }
+                                    Program::Unsupported(_) => None,
+                                };
 
-                        // Map UUID to String for response
-                        let map_owner_uuid = match r.map_owner_uuid {
-                            Some(uuid) => uuid.to_string(),
-                            None => String::new(),
-                        };
-                        // Map Vec<UUID> to Vec<String> for response
-                        let map_used_by: Vec<String> = r
-                            .map_used_by
-                            .unwrap_or(vec![])
-                            .iter()
-                            .map(|u| u.to_string())
-                            .collect();
-
-                        debug!("Pushing list result for {:?}", id);
-                        reply.results.push(ListResult {
-                            id,
-                            name,
-                            attach_info,
-                            location: loc,
-                            program_type,
-                            global_data: r.global_data.unwrap_or_default(),
-                            map_owner_uuid,
-                            map_pin_path: r.map_pin_path.unwrap_or_default(),
-                            map_used_by,
-                            bpf_id: r.kernel_info.id,
-                            loaded_at: r.kernel_info.loaded_at,
-                            tag: r.kernel_info.tag,
-                            gpl_compatible: r.kernel_info.gpl_compatible,
-                            map_ids: r.kernel_info.map_ids,
-                            btf_id: r.kernel_info.btf_id,
-                            bytes_xlated: r.kernel_info.bytes_xlated,
-                            jited: r.kernel_info.jited,
-                            bytes_jited: r.kernel_info.bytes_jited,
-                            bytes_memlock: r.kernel_info.bytes_memlock,
-                            verified_insns: r.kernel_info.verified_insns,
-                        })
+                                reply.results.push(reply_entry)
+                            }
+                        }
                     }
                     Ok(Response::new(reply))
                 }
@@ -544,11 +491,7 @@ mod test {
     async fn mock_serve(mut rx: Receiver<Command>) {
         while let Some(cmd) = rx.recv().await {
             match cmd {
-                Command::LoadXDP(args) => args.responder.send(Ok(Uuid::new_v4())).unwrap(),
-                Command::LoadTC(args) => args.responder.send(Ok(Uuid::new_v4())).unwrap(),
-                Command::LoadTracepoint(args) => args.responder.send(Ok(Uuid::new_v4())).unwrap(),
-                Command::LoadKprobe(args) => args.responder.send(Ok(Uuid::new_v4())).unwrap(),
-                Command::LoadUprobe(args) => args.responder.send(Ok(Uuid::new_v4())).unwrap(),
+                Command::Load(args) => args.responder.send(Ok(Uuid::new_v4())).unwrap(),
                 Command::Unload(args) => args.responder.send(Ok(())).unwrap(),
                 Command::List { responder, .. } => responder.send(Ok(vec![])).unwrap(),
                 Command::PullBytecode(args) => args.responder.send(Ok(())).unwrap(),

--- a/bpfd/src/serve.rs
+++ b/bpfd/src/serve.rs
@@ -83,7 +83,7 @@ pub async fn serve(config: Config, static_program_path: &str) -> anyhow::Result<
     // Load any static programs first
     if !static_programs.is_empty() {
         for prog in static_programs {
-            let uuid = bpf_manager.add_program(prog, None).await?;
+            let uuid = bpf_manager.add_program(prog).await?;
             info!("Loaded static program with UUID {}", uuid)
         }
     };

--- a/bpfd/src/static_program.rs
+++ b/bpfd/src/static_program.rs
@@ -6,27 +6,65 @@ use std::{
 };
 
 use anyhow::bail;
-use bpfd_api::{util::directories::CFGDIR_STATIC_PROGRAMS, ProgramType};
+use bpfd_api::{util::directories::CFGDIR_STATIC_PROGRAMS, ProgramType, TcProceedOn, XdpProceedOn};
 use log::{info, warn};
 use serde::Deserialize;
 use tokio::fs;
 
 use crate::{
     command::{
+        Direction,
         Location::{File, Image},
-        Metadata, Program, ProgramData, TcAttachInfo, TcProgram, TcProgramInfo,
-        TracepointAttachInfo, TracepointProgram, TracepointProgramInfo, XdpAttachInfo, XdpProgram,
-        XdpProgramInfo,
+        Program, ProgramData, TcProgram, TracepointProgram, XdpProgram,
     },
     oci_utils::BytecodeImage,
-    utils::{get_ifindex, read_to_string},
+    utils::read_to_string,
 };
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct XdpAttachInfo {
+    pub(crate) priority: i32,
+    pub(crate) iface: String,
+    pub(crate) proceed_on: XdpProceedOn,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TcAttachInfo {
+    pub(crate) priority: i32,
+    pub(crate) iface: String,
+    pub(crate) proceed_on: TcProceedOn,
+    pub(crate) direction: Direction,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TracepointAttachInfo {
+    pub(crate) tracepoint: String,
+}
+
+// TODO not yet implemented
+// #[derive(Debug, Clone, Deserialize)]
+// pub(crate) struct KprobeAttachInfo {
+//     pub(crate) fn_name: String,
+//     pub(crate) offset: u64,
+//     pub(crate) retprobe: bool,
+//     pub(crate) namespace: Option<String>,
+// }
+
+// #[derive(Debug, Clone, Deserialize)]
+// pub(crate) struct UprobeAttachInfo {
+//     pub(crate) fn_name: Option<String>,
+//     pub(crate) offset: u64,
+//     pub(crate) target: String,
+//     pub(crate) retprobe: bool,
+//     pub(crate) pid: Option<i32>,
+//     pub(crate) namespace: Option<String>,
+// }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct StaticProgramEntry {
     bytecode_image: Option<BytecodeImage>,
     file_path: Option<String>,
-    section_name: String,
+    name: String,
     global_data: HashMap<String, Vec<u8>>,
     program_type: ProgramType,
     xdp_attach: Option<XdpAttachInfo>,
@@ -106,75 +144,37 @@ pub(crate) async fn get_static_programs<P: AsRef<Path>>(
                         .expect("static program did not provide bytecode"),
                 ),
             };
+
+            let data = ProgramData::new(location, program.name, None, program.global_data, None);
             let prog = match program.program_type {
                 ProgramType::Xdp => {
                     if let Some(m) = program.xdp_attach {
-                        let if_index = get_ifindex(&m.iface)?;
-                        let metadata = Metadata::new(m.priority);
-                        Program::Xdp(XdpProgram::new(
-                            ProgramData::new(
-                                location,
-                                program.section_name.clone(),
-                                program.global_data,
-                                None,
-                                String::from("bpfd"),
-                            ),
-                            XdpProgramInfo {
-                                if_index,
-                                current_position: None,
-                                metadata,
-                                proceed_on: m.proceed_on,
-                                if_name: m.iface,
-                            },
-                        ))
+                        Program::Xdp(XdpProgram::new(data, m.priority, m.iface, m.proceed_on))
                     } else {
-                        bail!("invalid attach type for xdp program")
+                        bail!("invalid info for xdp program")
                     }
                 }
                 ProgramType::Tc => {
                     if let Some(m) = program.tc_attach {
-                        let if_index = get_ifindex(&m.iface)?;
-                        let metadata = Metadata::new(m.priority);
-                        Program::Tc(TcProgram {
-                            data: ProgramData::new(
-                                location,
-                                program.section_name.clone(),
-                                program.global_data,
-                                None,
-                                String::from("bpfd"),
-                            ),
-                            info: TcProgramInfo {
-                                if_index,
-                                current_position: None,
-                                metadata,
-                                proceed_on: m.proceed_on,
-                                if_name: m.iface,
-                                direction: m.direction,
-                            },
-                        })
+                        Program::Tc(TcProgram::new(
+                            data,
+                            m.priority,
+                            m.iface,
+                            m.proceed_on,
+                            m.direction,
+                        ))
                     } else {
                         bail!("invalid attach type for tc program")
                     }
                 }
                 ProgramType::Tracepoint => {
                     if let Some(m) = program.tracepoint_attach {
-                        Program::Tracepoint(TracepointProgram::new(
-                            ProgramData::new(
-                                location,
-                                program.section_name.clone(),
-                                program.global_data,
-                                None,
-                                String::from("bpfd"),
-                            ),
-                            TracepointProgramInfo {
-                                tracepoint: m.tracepoint,
-                            },
-                        ))
+                        Program::Tracepoint(TracepointProgram::new(data, m.tracepoint))
                     } else {
                         bail!("invalid attach type for tc program")
                     }
                 }
-                m => bail!("program type not yet supported: {:?}", m),
+                m => bail!("program type not yet supported to load statically: {:?}", m),
             };
 
             programs.push(prog)


### PR DESCRIPTION
This commit aims to simplify our internal api.  Specifically it removes many redundant types and centers the entire internal API around a Program Enum which contains all of the core information needed to load and maintain a program.

Most of the code deduplication comes out of command.rs and within our listing API. 

All internals of loading and pinning stay the same.

follows up https://github.com/bpfd-dev/bpfd/pull/656