### PR TITLE
separate dispatchers from programs in BpfManager

### DIFF
--- a/bpfd/src/multiprog/mod.rs
+++ b/bpfd/src/multiprog/mod.rs
@@ -28,7 +28,7 @@ pub(crate) enum Dispatcher {
 impl Dispatcher {
     pub async fn new(
         config: Option<&InterfaceConfig>,
-        programs: &mut [(Uuid, Program)],
+        programs: &mut [(&Uuid, &mut Program)],
         revision: u32,
         old_dispatcher: Option<Dispatcher>,
         image_manager: Sender<ImageManagerCommand>,
@@ -93,16 +93,23 @@ impl Dispatcher {
 
     pub(crate) fn next_revision(&self) -> u32 {
         let current = match self {
-            Dispatcher::Xdp(d) => d.revision,
-            Dispatcher::Tc(d) => d.revision,
+            Dispatcher::Xdp(d) => d.revision(),
+            Dispatcher::Tc(d) => d.revision(),
         };
         current.wrapping_add(1)
     }
 
-    pub(crate) fn if_name(&mut self) -> String {
+    pub(crate) fn if_name(&self) -> String {
         match self {
             Dispatcher::Xdp(d) => d.if_name(),
             Dispatcher::Tc(d) => d.if_name(),
+        }
+    }
+
+    pub(crate) fn num_extensions(&self) -> usize {
+        match self {
+            Dispatcher::Xdp(d) => d.num_extensions(),
+            Dispatcher::Tc(d) => d.num_extensions(),
         }
     }
 }


### PR DESCRIPTION
separate dispatchers from programs in BpfManager

Separate dispatchers and programs into their own unique types
since they currently have very different lifetime requirements
in the codebase today.

This includes adding getters/setters and helper traits for each
type.

Ultimately this now enables us to pass around a mutable reference
to a program throughout a program operation (load/delete/reload/etc)
which makes the entire cycle a bit more efficient now that we need
to update a program's kernel info AFTER load.