### PR TITLE
bpfd/csi: ephemeral inline volume scaffolding

### DIFF
--- a/bpfd-api/src/util.rs
+++ b/bpfd-api/src/util.rs
@@ -32,9 +32,13 @@ pub mod directories {
     pub const RTDIR_FS_XDP: &str = "/run/bpfd/fs/xdp";
     pub const RTDIR_FS_MAPS: &str = "/run/bpfd/fs/maps";
     pub const RTDIR_PROGRAMS: &str = "/run/bpfd/programs";
+    pub const STPATH_BPFD_SOCKET: &str = "/run/bpfd/bpfd.sock";
+    // The CSI socket must be in it's own sub directory so we can easily create a dedicated
+    // K8s volume mount for it.
+    pub const RTDIR_BPFD_CSI: &str = "/run/bpfd/csi";
+    pub const STPATH_BPFD_CSI_SOCKET: &str = "/run/bpfd/csi/csi.sock";
+
     // StateDirectory: /var/lib/bpfd/
     pub const STDIR: &str = "/var/lib/bpfd";
-    pub const STDIR_SOCKET: &str = "/var/lib/bpfd/sock";
-    pub const STPATH_BPFD_SOCKET: &str = "/var/lib/bpfd/sock/bpfd.sock";
     pub const BYTECODE_IMAGE_CONTENT_STORE: &str = "/var/lib/bpfd/io.bpfd.image.content";
 }

--- a/bpfd/src/main.rs
+++ b/bpfd/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> anyhow::Result<()> {
             create_dir_all(CFGDIR_STATIC_PROGRAMS)
                 .context("unable to create static programs directory")?;
 
-            create_dir_all(STDIR_SOCKET).context("unable to create socket directory")?;
+            create_dir_all(RTDIR_BPFD_CSI).context("unable to create socket directory")?;
 
             create_dir_all(BYTECODE_IMAGE_CONTENT_STORE)
                 .context("unable to create bytecode image store directory")?;

--- a/bpfd/src/serve.rs
+++ b/bpfd/src/serve.rs
@@ -23,11 +23,14 @@ use tonic::transport::{Server, ServerTlsConfig};
 
 pub use crate::certs::get_tls_config;
 use crate::{
-    bpf::BpfManager, errors::BpfdError, oci_utils::ImageManager, rpc::BpfdLoader,
-    static_program::get_static_programs, storage::StorageManager, utils::set_file_permissions,
+    bpf::BpfManager,
+    errors::BpfdError,
+    oci_utils::ImageManager,
+    rpc::BpfdLoader,
+    static_program::get_static_programs,
+    storage::StorageManager,
+    utils::{set_file_permissions, SOCK_MODE},
 };
-
-const SOCK_MODE: u32 = 0o0770;
 
 pub async fn serve(
     config: Config,
@@ -80,8 +83,6 @@ pub async fn serve(
         }
     }
 
-    let storage_manager = StorageManager::new();
-
     let (itx, irx) = mpsc::channel(32);
     let mut image_manager = ImageManager::new(BYTECODE_IMAGE_CONTENT_STORE, irx);
 
@@ -98,6 +99,8 @@ pub async fn serve(
         }
     };
     if csi_support {
+        let storage_manager = StorageManager::new();
+
         join!(
             join_listeners(listeners),
             bpf_manager.process_commands(),

--- a/bpfd/src/storage.rs
+++ b/bpfd/src/storage.rs
@@ -1,131 +1,81 @@
 // SPDX-License-Identifier: (MIT OR Apache-2.0)
 // Copyright Authors of bpfd
 
-use std::path::Path;
+use std::{collections::HashMap, fs::remove_file, path::Path};
 
 use async_trait::async_trait;
 use aya::maps::MapData;
+use bpfd_api::util::directories::STPATH_BPFD_CSI_SOCKET;
 use bpfd_csi::v1::{
-    controller_server::{Controller, ControllerServer},
+    identity_server::{Identity, IdentityServer},
     node_server::{Node, NodeServer},
-    ControllerExpandVolumeRequest, ControllerExpandVolumeResponse,
-    ControllerGetCapabilitiesRequest, ControllerGetCapabilitiesResponse,
-    ControllerGetVolumeRequest, ControllerGetVolumeResponse, ControllerModifyVolumeRequest,
-    ControllerModifyVolumeResponse, ControllerPublishVolumeRequest,
-    ControllerPublishVolumeResponse, ControllerUnpublishVolumeRequest,
-    ControllerUnpublishVolumeResponse, CreateSnapshotRequest, CreateSnapshotResponse,
-    CreateVolumeRequest, CreateVolumeResponse, DeleteSnapshotRequest, DeleteSnapshotResponse,
-    DeleteVolumeRequest, DeleteVolumeResponse, GetCapacityRequest, GetCapacityResponse,
-    ListSnapshotsRequest, ListSnapshotsResponse, ListVolumesRequest, ListVolumesResponse,
-    NodeExpandVolumeRequest, NodeExpandVolumeResponse, NodeGetCapabilitiesRequest,
-    NodeGetCapabilitiesResponse, NodeGetInfoRequest, NodeGetInfoResponse,
-    NodeGetVolumeStatsRequest, NodeGetVolumeStatsResponse, NodePublishVolumeRequest,
-    NodePublishVolumeResponse, NodeStageVolumeRequest, NodeStageVolumeResponse,
-    NodeUnpublishVolumeRequest, NodeUnpublishVolumeResponse, NodeUnstageVolumeRequest,
-    NodeUnstageVolumeResponse, ValidateVolumeCapabilitiesRequest,
-    ValidateVolumeCapabilitiesResponse,
+    node_service_capability, GetPluginCapabilitiesRequest, GetPluginCapabilitiesResponse,
+    GetPluginInfoRequest, GetPluginInfoResponse, NodeExpandVolumeRequest, NodeExpandVolumeResponse,
+    NodeGetCapabilitiesRequest, NodeGetCapabilitiesResponse, NodeGetInfoRequest,
+    NodeGetInfoResponse, NodeGetVolumeStatsRequest, NodeGetVolumeStatsResponse,
+    NodePublishVolumeRequest, NodePublishVolumeResponse, NodeServiceCapability,
+    NodeStageVolumeRequest, NodeStageVolumeResponse, NodeUnpublishVolumeRequest,
+    NodeUnpublishVolumeResponse, NodeUnstageVolumeRequest, NodeUnstageVolumeResponse, ProbeRequest,
+    ProbeResponse,
 };
 use log::info;
+use tokio::net::UnixListener;
+use tokio_stream::wrappers::UnixListenerStream;
 use tonic::{transport::Server, Request, Response, Status};
 
-use crate::{serve::shutdown_handler, utils::create_bpffs};
+use crate::{
+    serve::shutdown_handler,
+    utils::{create_bpffs, set_file_permissions, SOCK_MODE},
+};
+
+const DRIVER_NAME: &str = "csi.bpfd.dev";
+
 pub(crate) struct StorageManager {
-    csi_controller: CsiController,
+    csi_identity: CsiIdentity,
     csi_node: CsiNode,
 }
 
-struct CsiController {}
-
-#[async_trait]
-impl Controller for CsiController {
-    async fn create_volume(
-        &self,
-        _request: Request<CreateVolumeRequest>,
-    ) -> std::result::Result<Response<CreateVolumeResponse>, Status> {
-        todo!()
-    }
-
-    async fn delete_volume(
-        &self,
-        _request: Request<DeleteVolumeRequest>,
-    ) -> std::result::Result<Response<DeleteVolumeResponse>, Status> {
-        todo!()
-    }
-    async fn controller_publish_volume(
-        &self,
-        _request: Request<ControllerPublishVolumeRequest>,
-    ) -> std::result::Result<Response<ControllerPublishVolumeResponse>, Status> {
-        todo!()
-    }
-    async fn controller_unpublish_volume(
-        &self,
-        _request: Request<ControllerUnpublishVolumeRequest>,
-    ) -> std::result::Result<Response<ControllerUnpublishVolumeResponse>, Status> {
-        todo!()
-    }
-    async fn validate_volume_capabilities(
-        &self,
-        _request: Request<ValidateVolumeCapabilitiesRequest>,
-    ) -> std::result::Result<Response<ValidateVolumeCapabilitiesResponse>, Status> {
-        todo!()
-    }
-    async fn list_volumes(
-        &self,
-        _request: Request<ListVolumesRequest>,
-    ) -> std::result::Result<Response<ListVolumesResponse>, Status> {
-        todo!()
-    }
-    async fn get_capacity(
-        &self,
-        _request: Request<GetCapacityRequest>,
-    ) -> std::result::Result<Response<GetCapacityResponse>, Status> {
-        todo!()
-    }
-    async fn controller_get_capabilities(
-        &self,
-        _request: Request<ControllerGetCapabilitiesRequest>,
-    ) -> std::result::Result<Response<ControllerGetCapabilitiesResponse>, Status> {
-        todo!()
-    }
-    async fn create_snapshot(
-        &self,
-        _request: Request<CreateSnapshotRequest>,
-    ) -> std::result::Result<Response<CreateSnapshotResponse>, Status> {
-        todo!()
-    }
-    async fn delete_snapshot(
-        &self,
-        _request: Request<DeleteSnapshotRequest>,
-    ) -> std::result::Result<Response<DeleteSnapshotResponse>, Status> {
-        todo!()
-    }
-    async fn list_snapshots(
-        &self,
-        _request: Request<ListSnapshotsRequest>,
-    ) -> std::result::Result<Response<ListSnapshotsResponse>, Status> {
-        todo!()
-    }
-    async fn controller_expand_volume(
-        &self,
-        _request: Request<ControllerExpandVolumeRequest>,
-    ) -> std::result::Result<Response<ControllerExpandVolumeResponse>, Status> {
-        todo!()
-    }
-    async fn controller_get_volume(
-        &self,
-        _request: Request<ControllerGetVolumeRequest>,
-    ) -> std::result::Result<Response<ControllerGetVolumeResponse>, Status> {
-        todo!()
-    }
-    async fn controller_modify_volume(
-        &self,
-        _request: Request<ControllerModifyVolumeRequest>,
-    ) -> std::result::Result<Response<ControllerModifyVolumeResponse>, Status> {
-        todo!()
-    }
+struct CsiIdentity {
+    name: String,
+    version: String,
 }
 
-struct CsiNode {}
+struct CsiNode {
+    node_id: String,
+}
+
+#[async_trait]
+impl Identity for CsiIdentity {
+    async fn get_plugin_info(
+        &self,
+        _request: Request<GetPluginInfoRequest>,
+    ) -> Result<Response<GetPluginInfoResponse>, Status> {
+        return Ok(Response::new(GetPluginInfoResponse {
+            name: self.name.clone(),
+            vendor_version: self.version.clone(),
+            manifest: HashMap::new(),
+        }));
+    }
+
+    async fn probe(
+        &self,
+        _request: Request<ProbeRequest>,
+    ) -> Result<Response<ProbeResponse>, Status> {
+        return Ok(Response::new(ProbeResponse {
+            ..Default::default()
+        }));
+    }
+
+    // Actual caps are defined in the CSIDriver K8s resource.
+    async fn get_plugin_capabilities(
+        &self,
+        _request: Request<GetPluginCapabilitiesRequest>,
+    ) -> Result<Response<GetPluginCapabilitiesResponse>, Status> {
+        return Ok(Response::new(GetPluginCapabilitiesResponse {
+            ..Default::default()
+        }));
+    }
+}
 
 #[async_trait]
 impl Node for CsiNode {
@@ -133,77 +83,139 @@ impl Node for CsiNode {
         &self,
         _request: Request<NodeStageVolumeRequest>,
     ) -> std::result::Result<Response<NodeStageVolumeResponse>, tonic::Status> {
-        todo!()
+        return Err(Status::unimplemented(""));
     }
     async fn node_unstage_volume(
         &self,
         _request: Request<NodeUnstageVolumeRequest>,
     ) -> std::result::Result<Response<NodeUnstageVolumeResponse>, tonic::Status> {
-        todo!()
+        return Err(Status::unimplemented(""));
     }
     async fn node_publish_volume(
         &self,
-        _request: Request<NodePublishVolumeRequest>,
+        request: Request<NodePublishVolumeRequest>,
     ) -> std::result::Result<Response<NodePublishVolumeResponse>, tonic::Status> {
-        todo!()
+        let req = request.get_ref();
+        let volume_cap = &req.volume_capability;
+        let volume_id = &req.volume_id;
+        let target_path = &req.target_path;
+        let volume_context = &req.volume_context;
+        let read_only = &req.readonly;
+
+        info!(
+            "Received publish volume request with :\n\
+        volume_caps: {volume_cap:#?},\n\
+        volume_id: {volume_id},\n\
+        target_path: {target_path},\n\
+        volume_context: {volume_context:#?},\n\
+        read_only: {read_only}\n\
+        Sleeping for 60 seconds"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+
+        Ok(Response::new(NodePublishVolumeResponse {}))
     }
     async fn node_unpublish_volume(
         &self,
-        _request: Request<NodeUnpublishVolumeRequest>,
+        request: Request<NodeUnpublishVolumeRequest>,
     ) -> std::result::Result<Response<NodeUnpublishVolumeResponse>, tonic::Status> {
-        todo!()
+        let req = request.get_ref();
+        let volume_id = &req.volume_id;
+        let target_path = &req.target_path;
+        info!(
+            "Received unpublish volume request with :\n\
+        volume_id: {volume_id},\n\
+        target_path: {target_path}"
+        );
+
+        Ok(Response::new(NodeUnpublishVolumeResponse {}))
     }
     async fn node_get_volume_stats(
         &self,
         _request: Request<NodeGetVolumeStatsRequest>,
     ) -> std::result::Result<Response<NodeGetVolumeStatsResponse>, tonic::Status> {
-        todo!()
+        return Err(Status::unimplemented(""));
     }
     async fn node_expand_volume(
         &self,
         _request: Request<NodeExpandVolumeRequest>,
     ) -> std::result::Result<Response<NodeExpandVolumeResponse>, tonic::Status> {
-        todo!()
+        return Err(Status::unimplemented(""));
     }
     async fn node_get_capabilities(
         &self,
         _request: Request<NodeGetCapabilitiesRequest>,
     ) -> std::result::Result<Response<NodeGetCapabilitiesResponse>, tonic::Status> {
-        todo!()
+        return Ok(Response::new(NodeGetCapabilitiesResponse {
+            capabilities: vec![NodeServiceCapability {
+                r#type: Some(node_service_capability::Type::Rpc(
+                    node_service_capability::Rpc {
+                        r#type: node_service_capability::rpc::Type::Unknown.into(),
+                    },
+                )),
+            }],
+        }));
     }
+    // see https://github.com/container-storage-interface/spec/blob/master/spec.md#nodegetinfo
+    // for more information.
     async fn node_get_info(
         &self,
         _request: Request<NodeGetInfoRequest>,
     ) -> std::result::Result<Response<NodeGetInfoResponse>, tonic::Status> {
-        todo!()
+        return Ok(Response::new(NodeGetInfoResponse {
+            node_id: self.node_id.clone(),
+
+            max_volumes_per_node: 0,
+            accessible_topology: None,
+        }));
     }
 }
 
 impl StorageManager {
     pub fn new() -> Self {
-        let csi_controller = CsiController {};
-        let csi_node = CsiNode {};
+        const VERSION: &str = env!("CARGO_PKG_VERSION");
+        let node_id = std::env::var("KUBE_NODE_NAME")
+            .expect("cannot start bpfd csi driver if KUBE_NODE_NAME not set");
+
+        let csi_identity = CsiIdentity {
+            name: DRIVER_NAME.to_string(),
+            version: VERSION.to_string(),
+        };
+        let csi_node = CsiNode { node_id };
+
         Self {
-            csi_controller,
             csi_node,
+            csi_identity,
         }
     }
 
     pub async fn run(self) {
-        let addr = "[::1]:50052".parse().unwrap();
-        let controller_service = ControllerServer::new(self.csi_controller);
+        let path: &Path = Path::new(STPATH_BPFD_CSI_SOCKET);
+        // Listen on Unix socket
+        if path.exists() {
+            // Attempt to remove the socket, since bind fails if it exists
+            remove_file(path).expect("Panicked cleaning up stale csi socket");
+        }
+
+        let uds = UnixListener::bind(path)
+            .unwrap_or_else(|_| panic!("failed to bind {STPATH_BPFD_CSI_SOCKET}"));
+        let uds_stream = UnixListenerStream::new(uds);
+        set_file_permissions(STPATH_BPFD_CSI_SOCKET, SOCK_MODE).await;
+
         let node_service = NodeServer::new(self.csi_node);
+        let identity_service = IdentityServer::new(self.csi_identity);
         let serve = Server::builder()
-            .add_service(controller_service)
             .add_service(node_service)
-            .serve_with_shutdown(addr, shutdown_handler());
+            .add_service(identity_service)
+            .serve_with_incoming_shutdown(uds_stream, shutdown_handler());
 
         tokio::spawn(async move {
-            info!("CSI Plugin Listening on {addr}");
+            info!("CSI Plugin Listening on {}", path.display());
             if let Err(e) = serve.await {
                 eprintln!("Error = {e:?}");
             }
-            info!("Shutdown CSI Plugin {}", addr);
+            info!("Shutdown CSI Plugin Handler {}", path.display());
         });
     }
 

--- a/bpfd/src/utils.rs
+++ b/bpfd/src/utils.rs
@@ -15,6 +15,8 @@ use users::get_group_by_name;
 
 use crate::errors::BpfdError;
 
+pub(crate) const SOCK_MODE: u32 = 0o0770;
+
 // Like tokio::fs::read, but with O_NOCTTY set
 pub(crate) async fn read<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, BpfdError> {
     let mut data = vec![];


### PR DESCRIPTION
Implement the scaffolding required CSI endpoints for ephemeral inline volumes.


Currently the plugin just prints info on `NodePublishVolume` and `NodeUnPublishVolume`

i.e 

```
[INFO  bpfd::storage] Received publish volume request with :
    volume_caps: Some(
        VolumeCapability {
            access_mode: Some(
                AccessMode {
                    mode: SingleNodeWriter,
                },
            ),
            access_type: Some(
                Mount(
                    MountVolume {
                        fs_type: "",
                        mount_flags: [],
                        volume_mount_group: "",
                    },
                ),
            ),
        },
    ),
    volume_id: csi-413a3e6b41db24365286e94018a6644fa3190b8ab99b63269519562af55b8930,
    target_path: /var/lib/kubelet/pods/fcd164d3-cbe8-4044-8efd-c7f3e46b046d/volumes/kubernetes.io~csi/bpf-maps/mount,
    volume_context: {},
    read_only: false
```