### PR TITLE
Allow bpf programs with errors to be deleted in k8s

### DIFF
--- a/bpfd-operator/config/samples/bpfd.io_v1alpha1_tracepoint_tracepointprogram.yaml
+++ b/bpfd-operator/config/samples/bpfd.io_v1alpha1_tracepoint_tracepointprogram.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: tracepointprogram
   name: tracepoint-example
 spec:
-  sectionname: sys_enter_openat
+  sectionname: enter_openat
   # Select all nodes
   nodeselector: {}
   names: 

--- a/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
@@ -229,7 +229,7 @@ func (r *KprobeProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 
 		// If KprobeProgram is being deleted just exit
 		if isBeingDeleted {
-			return bpfdiov1alpha1.BpfProgCondNotLoaded, nil
+			return bpfdiov1alpha1.BpfProgCondUnloaded, nil
 		}
 
 		// Make sure if we're not selected just exit

--- a/bpfd-operator/controllers/bpfd-agent/tc-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tc-program.go
@@ -275,7 +275,7 @@ func (r *TcProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 
 		// If TcProgram is being deleted just break out and remove finalizer
 		if isBeingDeleted {
-			return bpfdiov1alpha1.BpfProgCondNotLoaded, nil
+			return bpfdiov1alpha1.BpfProgCondUnloaded, nil
 		}
 
 		// Make sure if we're not selected just exit

--- a/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/tracepoint-program.go
@@ -226,7 +226,7 @@ func (r *TracepointProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 
 		// If TracepointProgram is being deleted just exit
 		if isBeingDeleted {
-			return bpfdiov1alpha1.BpfProgCondNotLoaded, nil
+			return bpfdiov1alpha1.BpfProgCondUnloaded, nil
 		}
 
 		// Make sure if we're not selected just exit

--- a/bpfd-operator/controllers/bpfd-agent/uprobe-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/uprobe-program.go
@@ -233,7 +233,7 @@ func (r *UprobeProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 
 		// If UprobeProgram is being deleted just exit
 		if isBeingDeleted {
-			return bpfdiov1alpha1.BpfProgCondNotLoaded, nil
+			return bpfdiov1alpha1.BpfProgCondUnloaded, nil
 		}
 
 		// Make sure if we're not selected just exit

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program.go
@@ -262,7 +262,7 @@ func (r *XdpProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 
 		// If XdpProgram is being deleted just break out and remove finalizer
 		if isBeingDeleted {
-			return bpfdiov1alpha1.BpfProgCondNotLoaded, nil
+			return bpfdiov1alpha1.BpfProgCondUnloaded, nil
 		}
 
 		// Make sure if we're not selected just exit


### PR DESCRIPTION
Fixes #733, "Can't delete programs with errors in k8s"

The problem was that if a program was being deleted, and it wasn't loaded for some reason (most likely due to an error), the code returned BpfProgCondNotLoaded.  While this is true, the problem is that the code treats this condition as an error, so the delete never completes.  The fix is to return BpfProgCondUnloaded, which is what the code is expecting to see when a program is being deleted.

Also fixed a problem with the sample tracepoint yaml.