### PR TITLE
Fix new clippy error

### DIFF
--- a/xtask/src/build_ebpf.rs
+++ b/xtask/src/build_ebpf.rs
@@ -86,7 +86,7 @@ fn build_ebpf_files(
     include_path: PathBuf,
     out_path: PathBuf,
 ) -> anyhow::Result<()> {
-    let files = fs::read_dir(&src_path).unwrap();
+    let files = fs::read_dir(src_path).unwrap();
     for file in files {
         let p = file.unwrap().path();
         if let Some(ext) = p.extension() {


### PR DESCRIPTION
```
error: the borrowed expression implements the required traits
  --> xtask/src/build_ebpf.rs:89:30
   |
89 |     let files = fs::read_dir(&src_path).unwrap();
   |                              ^^^^^^^^^ help: change this to: `src_path`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
   = note: `-D clippy::needless-borrows-for-generic-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_borrows_for_generic_args)]`
```