### PR TITLE
Just keep one condition for each program object

### DIFF
--- a/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
+++ b/bpfd-operator/controllers/bpfd-agent/kprobe-program.go
@@ -278,7 +278,7 @@ func (r *KprobeProgramReconciler) reconcileBpfdProgram(ctx context.Context,
 		(mapOwnerStatus.isSet && (!mapOwnerStatus.isFound || !mapOwnerStatus.isLoaded)) {
 		r.Logger.V(1).Info("KprobeProgram exists on Node but is scheduled for deletion, not selected, or map not available",
 			"isDeleted", isBeingDeleted, "isSelected", isNodeSelected, "mapIsSet", mapOwnerStatus.isSet,
-			"mapIsFound", mapOwnerStatus.isFound, "mapIsLoaded", mapOwnerStatus.isLoaded)
+			"mapIsFound", mapOwnerStatus.isFound, "mapIsLoaded", mapOwnerStatus.isLoaded, "id", id)
 
 		if err := bpfdagentinternal.UnloadBpfdProgram(ctx, r.BpfdClient, *id); err != nil {
 			r.Logger.Error(err, "Failed to unload KprobeProgram")

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program_test.go
@@ -229,10 +229,14 @@ func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiConditio
 	// Require no requeue
 	require.False(t, res.Requeue)
 
-	// Check that the bpfProgram's status was correctly updated
+	// Get program object
 	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName0, Namespace: metav1.NamespaceAll}, bpfProgEth0)
 	require.NoError(t, err)
 
+	// Check that the bpfProgram's maps was correctly updated
+	require.Nil(t, bpfProgEth0.Spec.Maps)
+
+	// Check that the bpfProgram's status was correctly updated
 	// Make sure we only have 1 condition now
 	require.Equal(t, 1, len(bpfProgEth0.Status.Conditions))
 	// Make sure it's the right one.
@@ -322,18 +326,17 @@ func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiConditio
 			t.Fatal("Built bpfd LoadRequest does not match expected")
 		}
 
-		require.Nil(t, bpfProgEth0.Spec.Maps)
-
-		// Check that the bpfProgram's maps was correctly updated
+		// Get program object
 		err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
 		require.NoError(t, err)
 
+		// Check that the bpfProgram's maps was correctly updated
 		require.Nil(t, bpfProgEth1.Spec.Maps)
 
 		// Check that the bpfProgram's status was correctly updated
-		err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
-		require.NoError(t, err)
-
+		// Make sure we only have 1 condition now
+		require.Equal(t, 1, len(bpfProgEth1.Status.Conditions))
+		// Make sure it's the right one.
 		require.Equal(t, string(bpfdiov1alpha1.BpfProgCondLoaded), bpfProgEth1.Status.Conditions[0].Type)
 	}
 }

--- a/bpfd-operator/controllers/bpfd-agent/xdp-program_test.go
+++ b/bpfd-operator/controllers/bpfd-agent/xdp-program_test.go
@@ -32,6 +32,7 @@ import (
 
 	gobpfd "github.com/bpfd-dev/bpfd/clients/gobpfd/v1"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,183 +44,34 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func TestXdpProgramControllerCreate(t *testing.T) {
+// Runs the XdpProgramControllerCreate test.  If multiInterface = true, it
+// installs the program on two interfaces.  If multiCondition == true, it runs
+// it with an error case in which the program object has multiple conditions.
+func xdpProgramControllerCreate(t *testing.T, multiInterface bool, multiCondition bool) {
 	var (
 		name         = "fakeXdpProgram"
 		namespace    = "bpfd"
 		bytecodePath = "/tmp/hello.o"
 		sectionName  = "test"
 		fakeNode     = testutils.NewNode("fake-control-plane")
-		fakeInt      = "eth0"
+		fakeInt0     = "eth0"
+		fakeInt1     = "eth1"
 		ctx          = context.TODO()
-		bpfProgName  = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, fakeInt)
-		bpfProg      = &bpfdiov1alpha1.BpfProgram{}
-		fakeUID      = "ef71d42c-aa21-48e8-a697-82391d801a81"
-	)
-	// A XdpProgram object with metadata and spec.
-	Xdp := &bpfdiov1alpha1.XdpProgram{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: bpfdiov1alpha1.XdpProgramSpec{
-			BpfProgramCommon: bpfdiov1alpha1.BpfProgramCommon{
-				SectionName:  sectionName,
-				NodeSelector: metav1.LabelSelector{},
-				ByteCode: bpfdiov1alpha1.BytecodeSelector{
-					Path: &bytecodePath,
-				},
-			},
-			InterfaceSelector: bpfdiov1alpha1.InterfaceSelector{
-				Interfaces: &[]string{fakeInt},
-			},
-			Priority: 0,
-			ProceedOn: []bpfdiov1alpha1.XdpProceedOnValue{bpfdiov1alpha1.XdpProceedOnValue("pass"),
-				bpfdiov1alpha1.XdpProceedOnValue("dispatcher_return"),
-			},
-		},
-	}
-
-	// Objects to track in the fake client.
-	objs := []runtime.Object{fakeNode, Xdp}
-
-	// Register operator types with the runtime scheme.
-	s := scheme.Scheme
-	s.AddKnownTypes(bpfdiov1alpha1.SchemeGroupVersion, Xdp)
-	s.AddKnownTypes(bpfdiov1alpha1.SchemeGroupVersion, &bpfdiov1alpha1.XdpProgramList{})
-	s.AddKnownTypes(bpfdiov1alpha1.SchemeGroupVersion, &bpfdiov1alpha1.BpfProgram{})
-
-	// Create a fake client to mock API calls.
-	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
-
-	cli := agenttestutils.NewBpfdClientFake()
-
-	rc := ReconcilerCommon{
-		Client:     cl,
-		Scheme:     s,
-		BpfdClient: cli,
-		NodeName:   fakeNode.Name,
-	}
-
-	// Set development Logger so we can see all logs in tests.
-	logf.SetLogger(zap.New(zap.UseFlagOptions(&zap.Options{Development: true})))
-
-	// Create a ReconcileMemcached object with the scheme and fake client.
-	r := &XdpProgramReconciler{ReconcilerCommon: rc, ourNode: fakeNode}
-
-	// Mock request to simulate Reconcile() being called on an event for a
-	// watched resource .
-	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-
-	// First reconcile should create the bpf program object
-	res, err := r.Reconcile(ctx, req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	// Check the BpfProgram Object was created successfully
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
-	require.NoError(t, err)
-
-	require.NotEmpty(t, bpfProg)
-	// Finalizer is written
-	require.Equal(t, r.getFinalizer(), bpfProg.Finalizers[0])
-	// owningConfig Label was correctly set
-	require.Equal(t, bpfProg.Labels[internal.BpfProgramOwnerLabel], name)
-	// node Label was correctly set
-	require.Equal(t, bpfProg.Labels[internal.K8sHostLabel], fakeNode.Name)
-	// Type is set
-	require.Equal(t, r.getRecType(), bpfProg.Spec.Type)
-	// Require no requeue
-	require.False(t, res.Requeue)
-
-	// Update UID of bpfProgram with Fake UID since the fake API server won't
-	bpfProg.UID = types.UID(fakeUID)
-	err = cl.Update(ctx, bpfProg)
-	require.NoError(t, err)
-
-	// Second reconcile should create the bpfd Load Request and update the
-	// BpfProgram object's 'Programs' field.
-	res, err = r.Reconcile(ctx, req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	// Require no requeue
-	require.False(t, res.Requeue)
-	uuid := string(bpfProg.UID)
-
-	expectedLoadReq := &gobpfd.LoadRequest{
-		Bytecode: &gobpfd.BytecodeLocation{
-			Location: &gobpfd.BytecodeLocation_File{File: bytecodePath},
-		},
-		Name:        sectionName,
-		ProgramType: *internal.Xdp.Uint32(),
-		Metadata:    map[string]string{internal.UuidMetadataKey: uuid, internal.ProgramNameKey: name},
-		MapOwnerId:  nil,
-		Attach: &gobpfd.AttachInfo{
-			Info: &gobpfd.AttachInfo_XdpAttachInfo{
-				XdpAttachInfo: &gobpfd.XDPAttachInfo{
-					Priority:  0,
-					Iface:     fakeInt,
-					ProceedOn: []int32{2, 31},
-				},
-			},
-		},
-	}
-
-	// Check that the bpfProgram's programs was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
-	require.NoError(t, err)
-
-	// prog ID should already have been set
-	id, err := bpfdagentinternal.GetID(bpfProg)
-	require.NoError(t, err)
-
-	// Check the bpfLoadRequest was correctly Built
-	if !cmp.Equal(expectedLoadReq, cli.LoadRequests[int(*id)], protocmp.Transform()) {
-		t.Logf("Diff %v", cmp.Diff(expectedLoadReq, cli.LoadRequests[int(*id)], protocmp.Transform()))
-		t.Fatal("Built bpfd LoadRequest does not match expected")
-	}
-
-	require.Nil(t, bpfProg.Spec.Maps)
-
-	// Third reconcile should update the bpfPrograms status to loaded
-	res, err = r.Reconcile(ctx, req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	// Require no requeue
-	require.False(t, res.Requeue)
-
-	// Check that the bpfProgram's status was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName, Namespace: metav1.NamespaceAll}, bpfProg)
-	require.NoError(t, err)
-
-	require.Equal(t, string(bpfdiov1alpha1.BpfProgCondLoaded), bpfProg.Status.Conditions[0].Type)
-}
-
-func TestXdpProgramControllerCreateMultiIntf(t *testing.T) {
-	var (
-		name         = "fakeXdpProgram"
-		namespace    = "bpfd"
-		bytecodePath = "/tmp/hello.o"
-		sectionName  = "test"
-		fakeNode     = testutils.NewNode("fake-control-plane")
-		fakeInts     = []string{"eth0", "eth1"}
-		ctx          = context.TODO()
-		bpfProgName0 = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, fakeInts[0])
-		bpfProgName1 = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, fakeInts[1])
+		bpfProgName0 = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, fakeInt0)
+		bpfProgName1 = fmt.Sprintf("%s-%s-%s", name, fakeNode.Name, fakeInt1)
 		bpfProgEth0  = &bpfdiov1alpha1.BpfProgram{}
 		bpfProgEth1  = &bpfdiov1alpha1.BpfProgram{}
 		fakeUID0     = "ef71d42c-aa21-48e8-a697-82391d801a80"
 		fakeUID1     = "ef71d42c-aa21-48e8-a697-82391d801a81"
 	)
+
+	var fakeInts []string
+	if multiInterface {
+		fakeInts = []string{fakeInt0, fakeInt1}
+	} else {
+		fakeInts = []string{fakeInt0}
+	}
+
 	// A XdpProgram object with metadata and spec.
 	xdp := &bpfdiov1alpha1.XdpProgram{
 		ObjectMeta: metav1.ObjectMeta{
@@ -316,62 +168,6 @@ func TestXdpProgramControllerCreateMultiIntf(t *testing.T) {
 	// Require no requeue
 	require.False(t, res.Requeue)
 
-	// Third reconcile should update the first bpf program object's status
-	res, err = r.Reconcile(ctx, req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	require.False(t, res.Requeue)
-
-	// Fourth reconcile should create the second bpfProgram.
-	res, err = r.Reconcile(ctx, req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	// Require no requeue
-	require.False(t, res.Requeue)
-
-	// Check the Second BpfProgram Object was created successfully
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
-	require.NoError(t, err)
-
-	require.NotEmpty(t, bpfProgEth1)
-	// owningConfig Label was correctly set
-	require.Equal(t, bpfProgEth1.Labels[internal.BpfProgramOwnerLabel], name)
-	// node Label was correctly set
-	require.Equal(t, bpfProgEth1.Labels[internal.K8sHostLabel], fakeNode.Name)
-	// Finalizer is written
-	require.Equal(t, r.getFinalizer(), bpfProgEth1.Finalizers[0])
-	// Type is set
-	require.Equal(t, r.getRecType(), bpfProgEth1.Spec.Type)
-	// Require no requeue
-	require.False(t, res.Requeue)
-
-	// Update UID of bpfProgram with Fake UID since the fake API server won't
-	bpfProgEth1.UID = types.UID(fakeUID1)
-	err = cl.Update(ctx, bpfProgEth1)
-	require.NoError(t, err)
-
-	// Fifth reconcile should create the second bpfProgram.
-	res, err = r.Reconcile(ctx, req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	// Require no requeue
-	require.False(t, res.Requeue)
-
-	// Sixth reconcile should update the second bpfProgram's status.
-	res, err = r.Reconcile(ctx, req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	// Require no requeue
-	require.False(t, res.Requeue)
-
 	uuid0 := string(bpfProgEth0.UID)
 
 	expectedLoadReq0 := &gobpfd.LoadRequest{
@@ -393,27 +189,6 @@ func TestXdpProgramControllerCreateMultiIntf(t *testing.T) {
 		},
 	}
 
-	uuid1 := string(bpfProgEth1.UID)
-
-	expectedLoadReq1 := &gobpfd.LoadRequest{
-		Bytecode: &gobpfd.BytecodeLocation{
-			Location: &gobpfd.BytecodeLocation_File{File: bytecodePath},
-		},
-		Name:        sectionName,
-		ProgramType: *internal.Xdp.Uint32(),
-		Metadata:    map[string]string{internal.UuidMetadataKey: uuid1, internal.ProgramNameKey: name},
-		MapOwnerId:  nil,
-		Attach: &gobpfd.AttachInfo{
-			Info: &gobpfd.AttachInfo_XdpAttachInfo{
-				XdpAttachInfo: &gobpfd.XDPAttachInfo{
-					Priority:  0,
-					Iface:     fakeInts[1],
-					ProceedOn: []int32{2, 31},
-				},
-			},
-		},
-	}
-
 	// Check that the bpfProgram's maps was correctly updated
 	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName0, Namespace: metav1.NamespaceAll}, bpfProgEth0)
 	require.NoError(t, err)
@@ -422,43 +197,155 @@ func TestXdpProgramControllerCreateMultiIntf(t *testing.T) {
 	id0, err := bpfdagentinternal.GetID(bpfProgEth0)
 	require.NoError(t, err)
 
-	// Check that the bpfProgram's maps was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
-	require.NoError(t, err)
-
-	// prog ID should already have been set
-	id1, err := bpfdagentinternal.GetID(bpfProgEth1)
-	require.NoError(t, err)
-
 	// Check the bpfLoadRequest was correctly built
 	if !cmp.Equal(expectedLoadReq0, cli.LoadRequests[int(*id0)], protocmp.Transform()) {
 		t.Logf("Diff %v", cmp.Diff(expectedLoadReq0, cli.LoadRequests[int(*id0)], protocmp.Transform()))
 		t.Fatal("Built bpfd LoadRequest does not match expected")
 	}
 
-	// Check the bpfLoadRequest was correctly built
-	if !cmp.Equal(expectedLoadReq1, cli.LoadRequests[int(*id1)], protocmp.Transform()) {
-		t.Logf("Diff %v", cmp.Diff(expectedLoadReq1, cli.LoadRequests[int(*id1)], protocmp.Transform()))
-		t.Fatal("Built bpfd LoadRequest does not match expected")
+	// NOTE: THIS IS A TEST FOR AN ERROR PATH. THERE SHOULD NEVER BE MORE THAN
+	// ONE CONDITION.
+	if multiCondition {
+		// Add some random conditions and verify that the condition still gets
+		// updated correctly.
+		meta.SetStatusCondition(&bpfProgEth0.Status.Conditions, bpfdiov1alpha1.BpfProgCondBytecodeSelectorError.Condition())
+		if err := r.Status().Update(ctx, bpfProgEth0); err != nil {
+			r.Logger.V(1).Info("failed to set KprobeProgram object status")
+		}
+		meta.SetStatusCondition(&bpfProgEth0.Status.Conditions, bpfdiov1alpha1.BpfProgCondNotSelected.Condition())
+		if err := r.Status().Update(ctx, bpfProgEth0); err != nil {
+			r.Logger.V(1).Info("failed to set KprobeProgram object status")
+		}
+		// Make sure we have 2 conditions
+		require.Equal(t, 2, len(bpfProgEth0.Status.Conditions))
 	}
 
-	require.Nil(t, bpfProgEth0.Spec.Maps)
+	// Third reconcile should update the bpfPrograms status to loaded
+	res, err = r.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
 
-	// Check that the bpfProgram's maps was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
-	require.NoError(t, err)
-
-	require.Nil(t, bpfProgEth1.Spec.Maps)
+	// Require no requeue
+	require.False(t, res.Requeue)
 
 	// Check that the bpfProgram's status was correctly updated
 	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName0, Namespace: metav1.NamespaceAll}, bpfProgEth0)
 	require.NoError(t, err)
 
+	// Make sure we only have 1 condition now
+	require.Equal(t, 1, len(bpfProgEth0.Status.Conditions))
+	// Make sure it's the right one.
 	require.Equal(t, string(bpfdiov1alpha1.BpfProgCondLoaded), bpfProgEth0.Status.Conditions[0].Type)
 
-	// Check that the bpfProgram's status was correctly updated
-	err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
-	require.NoError(t, err)
+	if multiInterface {
+		// Fourth reconcile should create the second bpfProgram.
+		res, err = r.Reconcile(ctx, req)
+		if err != nil {
+			t.Fatalf("reconcile: (%v)", err)
+		}
 
-	require.Equal(t, string(bpfdiov1alpha1.BpfProgCondLoaded), bpfProgEth1.Status.Conditions[0].Type)
+		// Require no requeue
+		require.False(t, res.Requeue)
+
+		// Check the Second BpfProgram Object was created successfully
+		err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, bpfProgEth1)
+		// owningConfig Label was correctly set
+		require.Equal(t, bpfProgEth1.Labels[internal.BpfProgramOwnerLabel], name)
+		// node Label was correctly set
+		require.Equal(t, bpfProgEth1.Labels[internal.K8sHostLabel], fakeNode.Name)
+		// Finalizer is written
+		require.Equal(t, r.getFinalizer(), bpfProgEth1.Finalizers[0])
+		// Type is set
+		require.Equal(t, r.getRecType(), bpfProgEth1.Spec.Type)
+		// Require no requeue
+		require.False(t, res.Requeue)
+
+		// Update UID of bpfProgram with Fake UID since the fake API server won't
+		bpfProgEth1.UID = types.UID(fakeUID1)
+		err = cl.Update(ctx, bpfProgEth1)
+		require.NoError(t, err)
+
+		// Fifth reconcile should create the second bpfProgram.
+		res, err = r.Reconcile(ctx, req)
+		if err != nil {
+			t.Fatalf("reconcile: (%v)", err)
+		}
+
+		// Require no requeue
+		require.False(t, res.Requeue)
+
+		// Sixth reconcile should update the second bpfProgram's status.
+		res, err = r.Reconcile(ctx, req)
+		if err != nil {
+			t.Fatalf("reconcile: (%v)", err)
+		}
+
+		// Require no requeue
+		require.False(t, res.Requeue)
+
+		uuid1 := string(bpfProgEth1.UID)
+
+		expectedLoadReq1 := &gobpfd.LoadRequest{
+			Bytecode: &gobpfd.BytecodeLocation{
+				Location: &gobpfd.BytecodeLocation_File{File: bytecodePath},
+			},
+			Name:        sectionName,
+			ProgramType: *internal.Xdp.Uint32(),
+			Metadata:    map[string]string{internal.UuidMetadataKey: uuid1, internal.ProgramNameKey: name},
+			MapOwnerId:  nil,
+			Attach: &gobpfd.AttachInfo{
+				Info: &gobpfd.AttachInfo_XdpAttachInfo{
+					XdpAttachInfo: &gobpfd.XDPAttachInfo{
+						Priority:  0,
+						Iface:     fakeInts[1],
+						ProceedOn: []int32{2, 31},
+					},
+				},
+			},
+		}
+
+		// Check that the bpfProgram's maps was correctly updated
+		err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
+		require.NoError(t, err)
+
+		// prog ID should already have been set
+		id1, err := bpfdagentinternal.GetID(bpfProgEth1)
+		require.NoError(t, err)
+
+		// Check the bpfLoadRequest was correctly built
+		if !cmp.Equal(expectedLoadReq1, cli.LoadRequests[int(*id1)], protocmp.Transform()) {
+			t.Logf("Diff %v", cmp.Diff(expectedLoadReq1, cli.LoadRequests[int(*id1)], protocmp.Transform()))
+			t.Fatal("Built bpfd LoadRequest does not match expected")
+		}
+
+		require.Nil(t, bpfProgEth0.Spec.Maps)
+
+		// Check that the bpfProgram's maps was correctly updated
+		err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
+		require.NoError(t, err)
+
+		require.Nil(t, bpfProgEth1.Spec.Maps)
+
+		// Check that the bpfProgram's status was correctly updated
+		err = cl.Get(ctx, types.NamespacedName{Name: bpfProgName1, Namespace: metav1.NamespaceAll}, bpfProgEth1)
+		require.NoError(t, err)
+
+		require.Equal(t, string(bpfdiov1alpha1.BpfProgCondLoaded), bpfProgEth1.Status.Conditions[0].Type)
+	}
+}
+
+func TestXdpProgramControllerCreate(t *testing.T) {
+	xdpProgramControllerCreate(t, false, false)
+}
+
+func TestXdpProgramControllerCreateMultiIntf(t *testing.T) {
+	xdpProgramControllerCreate(t, true, false)
+}
+
+func TestUpdateStatus(t *testing.T) {
+	xdpProgramControllerCreate(t, false, true)
 }

--- a/bpfd-operator/controllers/bpfd-operator/common.go
+++ b/bpfd-operator/controllers/bpfd-operator/common.go
@@ -80,7 +80,7 @@ func reconcileBpfProgram(ctx context.Context, rec ProgramReconciler, prog client
 	opts := []client.ListOption{client.MatchingLabels{internal.BpfProgramOwnerLabel: progName}}
 
 	if err := r.List(ctx, bpfPrograms, opts...); err != nil {
-		r.Logger.V(1).Error(err, "failed to get freshPrograms for full reconcile")
+		r.Logger.Error(err, "failed to get freshPrograms for full reconcile")
 		return ctrl.Result{}, nil
 	}
 
@@ -151,7 +151,7 @@ func (r *ReconcilerCommon) removeFinalizer(ctx context.Context, prog client.Obje
 	if changed := controllerutil.RemoveFinalizer(prog, finalizer); changed {
 		err := r.Update(ctx, prog)
 		if err != nil {
-			r.Logger.V(1).Error(err, "failed to remove bpfProgram Finalizer")
+			r.Logger.Error(err, "failed to remove bpfProgram Finalizer")
 			return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 		}
 	}
@@ -206,7 +206,6 @@ func (r *ReconcilerCommon) updateCondition(ctx context.Context, obj client.Objec
 				} else {
 					// We're changing the condition, so delete this one.  The
 					// new condition will be added below.
-					r.Logger.V(1).Info("removing condition", "condition", (*conditions)[0].Type)
 					meta.RemoveStatusCondition(conditions, (*conditions)[0].Type)
 				}
 			}
@@ -217,7 +216,6 @@ func (r *ReconcilerCommon) updateCondition(ctx context.Context, obj client.Objec
 				// and add the new one below.
 				r.Logger.Info("more than one BpfProgramCondition", "numConditions", numConditions)
 				for _, c := range *conditions {
-					r.Logger.Info("removing condition", "condition", c.Type)
 					meta.RemoveStatusCondition(conditions, c.Type)
 				}
 			}

--- a/bpfd-operator/controllers/bpfd-operator/kprobe-program.go
+++ b/bpfd-operator/controllers/bpfd-operator/kprobe-program.go
@@ -19,7 +19,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -113,25 +112,5 @@ func (r *KprobeProgramReconciler) updateStatus(ctx context.Context, name string,
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	if prog.Status.Conditions != nil {
-		// Get most recent condition
-		recentIdx := len(prog.Status.Conditions) - 1
-
-		// If the most recent condition is the same as input, just return.
-		if prog.Status.Conditions[recentIdx].Type == string(cond) {
-			return ctrl.Result{}, nil
-		} else {
-			// Remove the input condition from the list if it exists (may no exist)
-			// because the SetStatusCondition() doesn't append if it is already in the list.
-			meta.RemoveStatusCondition(&prog.Status.Conditions, string(cond))
-		}
-	}
-	meta.SetStatusCondition(&prog.Status.Conditions, cond.Condition(message))
-
-	if err := r.Status().Update(ctx, prog); err != nil {
-		r.Logger.V(1).Info("failed to set KprobeProgram object status...requeuing")
-		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
-	}
-
-	return ctrl.Result{}, nil
+	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfd-operator/controllers/bpfd-operator/tc-program.go
+++ b/bpfd-operator/controllers/bpfd-operator/tc-program.go
@@ -19,7 +19,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -113,25 +112,5 @@ func (r *TcProgramReconciler) updateStatus(ctx context.Context, name string, con
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	if prog.Status.Conditions != nil {
-		// Get most recent condition
-		recentIdx := len(prog.Status.Conditions) - 1
-
-		// If the most recent condition is the same as input, just return.
-		if prog.Status.Conditions[recentIdx].Type == string(cond) {
-			return ctrl.Result{}, nil
-		} else {
-			// Remove the input condition from the list if it exists (may no exist)
-			// because the SetStatusCondition() doesn't append if it is already in the list.
-			meta.RemoveStatusCondition(&prog.Status.Conditions, string(cond))
-		}
-	}
-	meta.SetStatusCondition(&prog.Status.Conditions, cond.Condition(message))
-
-	if err := r.Status().Update(ctx, prog); err != nil {
-		r.Logger.V(1).Info("failed to set TcProgram object status...requeuing")
-		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
-	}
-
-	return ctrl.Result{}, nil
+	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfd-operator/controllers/bpfd-operator/tracepoint-program.go
+++ b/bpfd-operator/controllers/bpfd-operator/tracepoint-program.go
@@ -19,7 +19,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -113,25 +112,5 @@ func (r *TracepointProgramReconciler) updateStatus(ctx context.Context, name str
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
 
-	if prog.Status.Conditions != nil {
-		// Get most recent condition
-		recentIdx := len(prog.Status.Conditions) - 1
-
-		// If the most recent condition is the same as input, just return.
-		if prog.Status.Conditions[recentIdx].Type == string(cond) {
-			return ctrl.Result{}, nil
-		} else {
-			// Remove the input condition from the list if it exists (may no exist)
-			// because the SetStatusCondition() doesn't append if it is already in the list.
-			meta.RemoveStatusCondition(&prog.Status.Conditions, string(cond))
-		}
-	}
-	meta.SetStatusCondition(&prog.Status.Conditions, cond.Condition(message))
-
-	if err := r.Status().Update(ctx, prog); err != nil {
-		r.Logger.V(1).Info("failed to set Tracepoint object status...requeuing")
-		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
-	}
-
-	return ctrl.Result{}, nil
+	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfd-operator/controllers/bpfd-operator/xdp-program.go
+++ b/bpfd-operator/controllers/bpfd-operator/xdp-program.go
@@ -19,7 +19,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -114,25 +113,6 @@ func (r *XdpProgramReconciler) updateStatus(ctx context.Context, name string, co
 		r.Logger.V(1).Error(err, "failed to get fresh XdpProgram object...requeuing")
 		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
 	}
-	if prog.Status.Conditions != nil {
-		// Get most recent condition
-		recentIdx := len(prog.Status.Conditions) - 1
 
-		// If the most recent condition is the same as input, just return.
-		if prog.Status.Conditions[recentIdx].Type == string(cond) {
-			return ctrl.Result{}, nil
-		} else {
-			// Remove the input condition from the list if it exists (may no exist)
-			// because the SetStatusCondition() doesn't append if it is already in the list.
-			meta.RemoveStatusCondition(&prog.Status.Conditions, string(cond))
-		}
-	}
-	meta.SetStatusCondition(&prog.Status.Conditions, cond.Condition(message))
-
-	if err := r.Status().Update(ctx, prog); err != nil {
-		r.Logger.V(1).Info("failed to set XdpProgram object status...requeuing")
-		return ctrl.Result{Requeue: true, RequeueAfter: retryDurationOperator}, nil
-	}
-
-	return ctrl.Result{}, nil
+	return r.ReconcilerCommon.updateCondition(ctx, prog, &prog.Status.Conditions, cond, message)
 }

--- a/bpfd-operator/pkg/helpers/helpers.go
+++ b/bpfd-operator/pkg/helpers/helpers.go
@@ -454,12 +454,24 @@ func IsBpfdDeployed() bool {
 	return false
 }
 
-func IsBpfProgramConditionFailure(conditionType string) bool {
-	if conditionType == string(bpfdiov1alpha1.BpfProgCondNotLoaded) ||
-		conditionType == string(bpfdiov1alpha1.BpfProgCondNotUnloaded) ||
-		conditionType == string(bpfdiov1alpha1.BpfProgCondMapOwnerNotFound) ||
-		conditionType == string(bpfdiov1alpha1.BpfProgCondMapOwnerNotLoaded) ||
-		conditionType == string(bpfdiov1alpha1.BpfProgCondBytecodeSelectorError) {
+func IsBpfProgramConditionFailure(conditions *[]metav1.Condition) bool {
+	if conditions == nil || *conditions == nil || len(*conditions) == 0 {
+		return true
+	}
+
+	numConditions := len(*conditions)
+
+	if numConditions > 1 {
+		// We should only ever have one condition so log a message, but
+		// still look at (*conditions)[0].
+		log.Info("more than one BpfProgramCondition", "numConditions", numConditions)
+	}
+
+	if (*conditions)[0].Type == string(bpfdiov1alpha1.BpfProgCondNotLoaded) ||
+		(*conditions)[0].Type == string(bpfdiov1alpha1.BpfProgCondNotUnloaded) ||
+		(*conditions)[0].Type == string(bpfdiov1alpha1.BpfProgCondMapOwnerNotFound) ||
+		(*conditions)[0].Type == string(bpfdiov1alpha1.BpfProgCondMapOwnerNotLoaded) ||
+		(*conditions)[0].Type == string(bpfdiov1alpha1.BpfProgCondBytecodeSelectorError) {
 		return true
 	}
 

--- a/bpfd-operator/pkg/helpers/helpers.go
+++ b/bpfd-operator/pkg/helpers/helpers.go
@@ -305,6 +305,31 @@ func GetMaps(c *bpfdclientset.Clientset, ProgramName string, mapNames []string) 
 // 	return nil
 // }
 
+// Returns true if loaded.  False if not.  Also returns the condition type.
+func isProgLoaded(conditions *[]metav1.Condition) (bool, string) {
+	// Get most recent condition
+	conLen := len(*conditions)
+
+	if conLen <= 0 {
+		return false, "None"
+	}
+
+	if conLen > 1 {
+		// We should never have more than one condition. However, if we do, log
+		// a message and still check the first condtion which is where the valid
+		// one should be.
+		log.Info("Too many conditions: %d", conLen)
+	}
+
+	condition := (*conditions)[0]
+
+	if condition.Type != string(bpfdiov1alpha1.ProgramReconcileSuccess) {
+		return false, condition.Type
+	}
+
+	return true, condition.Type
+}
+
 func isKprobebpfdProgLoaded(c *bpfdclientset.Clientset, progConfName string) wait.ConditionFunc {
 	ctx := context.Background()
 
@@ -315,19 +340,10 @@ func isKprobebpfdProgLoaded(c *bpfdclientset.Clientset, progConfName string) wai
 			return false, err
 		}
 
-		// Get most recent condition
-		conLen := len(bpfProgConfig.Status.Conditions)
+		progLoaded, condType := isProgLoaded(&bpfProgConfig.Status.Conditions)
 
-		if conLen <= 0 {
-			return false, nil
-		}
-
-		recentIdx := len(bpfProgConfig.Status.Conditions) - 1
-
-		condition := bpfProgConfig.Status.Conditions[recentIdx]
-
-		if condition.Type != string(bpfdiov1alpha1.ProgramReconcileSuccess) {
-			log.Info("kprobeProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condition.Type)
+		if !progLoaded {
+			log.Info("kprobProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condType)
 			return false, nil
 		}
 
@@ -345,19 +361,10 @@ func isTcbpfdProgLoaded(c *bpfdclientset.Clientset, progConfName string) wait.Co
 			return false, err
 		}
 
-		// Get most recent condition
-		conLen := len(bpfProgConfig.Status.Conditions)
+		progLoaded, condType := isProgLoaded(&bpfProgConfig.Status.Conditions)
 
-		if conLen <= 0 {
-			return false, nil
-		}
-
-		recentIdx := len(bpfProgConfig.Status.Conditions) - 1
-
-		condition := bpfProgConfig.Status.Conditions[recentIdx]
-
-		if condition.Type != string(bpfdiov1alpha1.ProgramReconcileSuccess) {
-			log.Info("tcProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condition.Type)
+		if !progLoaded {
+			log.Info("tcProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condType)
 			return false, nil
 		}
 
@@ -375,19 +382,10 @@ func isTracepointbpfdProgLoaded(c *bpfdclientset.Clientset, progConfName string)
 			return false, err
 		}
 
-		// Get most recent condition
-		conLen := len(bpfProgConfig.Status.Conditions)
+		progLoaded, condType := isProgLoaded(&bpfProgConfig.Status.Conditions)
 
-		if conLen <= 0 {
-			return false, nil
-		}
-
-		recentIdx := len(bpfProgConfig.Status.Conditions) - 1
-
-		condition := bpfProgConfig.Status.Conditions[recentIdx]
-
-		if condition.Type != string(bpfdiov1alpha1.ProgramReconcileSuccess) {
-			log.Info("tracepointProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condition.Type)
+		if !progLoaded {
+			log.Info("tracepointProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condType)
 			return false, nil
 		}
 
@@ -405,19 +403,10 @@ func isXdpbpfdProgLoaded(c *bpfdclientset.Clientset, progConfName string) wait.C
 			return false, err
 		}
 
-		// Get most recent condition
-		conLen := len(bpfProgConfig.Status.Conditions)
+		progLoaded, condType := isProgLoaded(&bpfProgConfig.Status.Conditions)
 
-		if conLen <= 0 {
-			return false, nil
-		}
-
-		recentIdx := len(bpfProgConfig.Status.Conditions) - 1
-
-		condition := bpfProgConfig.Status.Conditions[recentIdx]
-
-		if condition.Type != string(bpfdiov1alpha1.ProgramReconcileSuccess) {
-			log.Info("xdpProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condition.Type)
+		if !progLoaded {
+			log.Info("xdpProgram: %s not ready with condition: %s, waiting until timeout", progConfName, condType)
 			return false, nil
 		}
 
@@ -437,10 +426,10 @@ func WaitForBpfProgConfLoad(c *bpfdclientset.Clientset, progName string, timeout
 		return wait.PollImmediate(time.Second, timeout, isXdpbpfdProgLoaded(c, progName))
 	case Tracepoint:
 		return wait.PollImmediate(time.Second, timeout, isTracepointbpfdProgLoaded(c, progName))
-	// case Uprobe: not covered because it doesn't have a ProgramType.  However,
-	// the only case currently used is Xdp, so it's not needed now.  If we need
-	// to support uprobes in the future, we could replace ProgramType with
-	// something else, like the string representation of the program type.
+	// TODO: case Uprobe: not covered.  Since Uprobe has the same ProgramType as
+	// Kprobe, we need a different way to distinguish them.  Options include
+	// creating an internal ProgramType for Uprobe or using a different
+	// identifier such as the string representation of the program type.
 	default:
 		return fmt.Errorf("unknown bpf program type: %s", progType)
 	}

--- a/bpfd-operator/pkg/helpers/helpers.go
+++ b/bpfd-operator/pkg/helpers/helpers.go
@@ -314,13 +314,6 @@ func isProgLoaded(conditions *[]metav1.Condition) (bool, string) {
 		return false, "None"
 	}
 
-	if conLen > 1 {
-		// We should never have more than one condition. However, if we do, log
-		// a message and still check the first condtion which is where the valid
-		// one should be.
-		log.Info("Too many conditions: %d", conLen)
-	}
-
 	condition := (*conditions)[0]
 
 	if condition.Type != string(bpfdiov1alpha1.ProgramReconcileSuccess) {


### PR DESCRIPTION
All of the code assumes that only the last condition counts.  However, that's not how conditions work.  This change modifies our behavior so that we only maintain the one (most recent) condition for each program object, which is a step toward the resolution of issue #430.

Part of the solution is to create a common updateCondition() function for the bpfd-operator that is used for all program types which removes some code duplication and is a small step toward the resolution of issue #709

This also removes code duplication in xdp-program_test.go, which is a small step toward the resolution of issue #710.