### PR TITLE
bpfctl calls fail when using Unix socket

### DIFF
--- a/bpfctl/src/main.rs
+++ b/bpfctl/src/main.rs
@@ -840,8 +840,8 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn execute_request_unix(command: &Commands, path: String) -> anyhow::Result<()> {
-    // URI is ignored on UDS, so any parsable string works.
-    let address = String::from("https://localhost");
+    // Format address to something like: "unix://run/bpfd/bpfd.sock"
+    let address = format!("unix:/{path}");
     let channel = Endpoint::try_from(address)?
         .connect_with_connector(service_fn(move |_: Uri| UnixStream::connect(path.clone())))
         .await?;


### PR DESCRIPTION
When using a Unix socket, bpfctl calls to bpfd fail:

```
$ bpfctl list
Error = transport error

Caused by:
    0: error trying to connect: Connecting to HTTPS without TLS enabled
    1: Connecting to HTTPS without TLS enabled
Error: Failed to execute request
```

To use a Unix socket, add/modify the bpfd.toml file and restart bpfd:

```
sudo vi /etc/bpfd/bpfd.toml
[[grpc.endpoints]]
  type = "unix"
  enabled = true
  path = "/run/bpfd/bpfd.sock"
```

The fix is to update the address being passed to bpfd.