### PR TITLE
bpfd: bpfd panic on unload of id not owned by bpfd

### DIFF
--- a/bpfd/src/bpf.rs
+++ b/bpfd/src/bpf.rs
@@ -615,7 +615,15 @@ impl BpfManager {
 
     pub(crate) async fn remove_program(&mut self, id: u32) -> Result<(), BpfdError> {
         debug!("BpfManager::remove_program() id: {id}");
-        let mut prog = self.programs.remove(&id).unwrap();
+        let mut prog = match self.programs.remove(&id) {
+            Some(p) => p,
+            None => {
+                return Err(BpfdError::Error(format!(
+                    "Program {0} does not exist or was not created by bpfd",
+                    id,
+                )));
+            }
+        };
 
         let map_owner_id = prog.data()?.map_owner_id();
 


### PR DESCRIPTION
bpfd panics on unload with an id that is not of a bpfd program:

```
 bpfctl unload 22222
Error = status: Unknown, message: "transport error", details: [], metadata: MetadataMap { headers: {} }

Caused by:
    0: transport error
    1: connection error: unexpected end of file
    2: unexpected end of file
```

```
Oct 02 16:53:54 ebpf03 bpfd[1032526]: thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', bpfd/src/bpf.rs:618:50
Oct 02 16:53:54 ebpf03 bpfd[1032526]: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```