### PR TITLE
Fix logging

### DIFF
--- a/bpfd-operator/config/bpfd-deployment/config.yaml
+++ b/bpfd-operator/config/bpfd-deployment/config.yaml
@@ -7,6 +7,9 @@ data:
   ## Can be configured at runtime
   bpfd.agent.image: quay.io/bpfd/bpfd-agent:latest
   bpfd.image: quay.io/bpfd/bpfd:latest
+  ## Can be set to "info", "debug", or "trace"
+  bpfd.agent.log.level: "info"
+  ## See https://docs.rs/env_logger/latest/env_logger/ for configuration options
   bpfd.log.level: "info"
   ## Must be configured at startup
   bpfd.toml: |

--- a/bpfd-operator/config/bpfd-deployment/daemonset-csi.yaml
+++ b/bpfd-operator/config/bpfd-deployment/daemonset-csi.yaml
@@ -88,7 +88,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: bpfd-config
-                key: bpfd.log.level
+                key: bpfd.agent.log.level
         volumeMounts:
         - name: bpfd-sock
           mountPath: /bpfd-sock

--- a/bpfd-operator/config/bpfd-deployment/daemonset.yaml
+++ b/bpfd-operator/config/bpfd-deployment/daemonset.yaml
@@ -78,7 +78,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: bpfd-config
-                key: bpfd.log.level
+                key: bpfd.agent.log.level
         volumeMounts:
         - name: bpfd-sock
           mountPath: /bpfd-sock

--- a/bpfd-operator/config/default/kustomization.yaml
+++ b/bpfd-operator/config/default/kustomization.yaml
@@ -24,7 +24,6 @@ namePrefix: bpfd-
 # endpoint w/o any authn/z, please comment the following line.
 patchesStrategicMerge:
 - manager_auth_proxy_patch.yaml
-- patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/bpfd-operator/config/default/patch.yaml
+++ b/bpfd-operator/config/default/patch.yaml
@@ -1,9 +1,0 @@
-## Activate debug logging for bpfd-daemon
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config
-  namespace: kube-system
-data:
-  ## Can be configured at runtime
-  bpfd.log.level: debug

--- a/bpfd-operator/controllers/bpfd-operator/configmap.go
+++ b/bpfd-operator/controllers/bpfd-operator/configmap.go
@@ -253,12 +253,15 @@ func LoadAndConfigureBpfdDs(config *corev1.ConfigMap, path string) *appsv1.Daemo
 	bpfdImage := config.Data["bpfd.image"]
 	bpfdAgentImage := config.Data["bpfd.agent.image"]
 	bpfdLogLevel := config.Data["bpfd.log.level"]
+	bpfdAgentLogLevel := config.Data["bpfd.agent.log.level"]
 
 	// Annotate the log level on the ds so we get automatic restarts on changes.
 	if staticBpfdDeployment.Spec.Template.ObjectMeta.Annotations == nil {
 		staticBpfdDeployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
 	}
+
 	staticBpfdDeployment.Spec.Template.ObjectMeta.Annotations["bpfd.dev.bpfd.loglevel"] = bpfdLogLevel
+	staticBpfdDeployment.Spec.Template.ObjectMeta.Annotations["bpfd.dev.bpfd.agent.loglevel"] = bpfdAgentLogLevel
 	staticBpfdDeployment.Name = "bpfd-daemon"
 	staticBpfdDeployment.Namespace = config.Namespace
 	staticBpfdDeployment.Spec.Template.Spec.Containers[0].Image = bpfdImage

--- a/bpfd/src/command.rs
+++ b/bpfd/src/command.rs
@@ -20,6 +20,7 @@ use bpfd_api::{
     ParseError, ProgramType, TcProceedOn, XdpProceedOn,
 };
 use chrono::{prelude::DateTime, Local};
+use log::info;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc::Sender, oneshot};
 
@@ -424,8 +425,12 @@ impl ProgramData {
         match self.location.get_program_bytes(image_manager).await {
             Err(e) => Err(e),
             Ok((v, s)) => {
-                match self.location {
-                    Location::Image(_) => {
+                match &self.location {
+                    Location::Image(l) => {
+                        info!(
+                            "Loading program bytecode from container image: {}",
+                            l.get_url()
+                        );
                         // If program name isn't provided and we're loading from a container
                         // image use the program name provided in the image metadata, otherwise
                         // always use the provided program name.
@@ -440,7 +445,9 @@ impl ProgramData {
                             });
                         }
                     }
-                    Location::File(_) => {}
+                    Location::File(l) => {
+                        info!("Loading program bytecode from file: {}", l);
+                    }
                 }
                 self.program_bytes = v;
                 Ok(())

--- a/bpfd/src/main.rs
+++ b/bpfd/src/main.rs
@@ -156,8 +156,8 @@ fn drop_linux_capabilities() {
     let res = match User::from_uid(uid) {
         Ok(res) => res.unwrap(),
         Err(e) => {
-            debug!("Unable to map user id {} to a name. err: {}", uid, e);
-            info!(
+            warn!("Unable to map user id {} to a name. err: {}", uid, e);
+            debug!(
                 "Running as user id {}, skip dropping all capabilities for spawned threads",
                 uid
             );
@@ -176,7 +176,7 @@ fn drop_linux_capabilities() {
         drop_all_cap(caps::CapSet::Inheritable);
         drop_all_cap(caps::CapSet::Permitted);
     } else {
-        info!(
+        debug!(
             "Running as user {}, skip dropping all capabilities for spawned threads",
             res.name
         );

--- a/bpfd/src/oci_utils/cosign.rs
+++ b/bpfd/src/oci_utils/cosign.rs
@@ -26,7 +26,7 @@ impl CosignVerifier {
         // We must use spawn_blocking here.
         // See: https://docs.rs/sigstore/0.7.2/sigstore/oauth/openidflow/index.html
         let repo: sigstore::errors::Result<SigstoreRepository> = spawn_blocking(|| {
-            info!("Downloading data from Sigstore TUF repository");
+            info!("Starting Cosign Verifier, downloading data from Sigstore TUF repository");
             sigstore::tuf::SigstoreRepository::fetch(None)
         })
         .await
@@ -79,6 +79,7 @@ impl CosignVerifier {
             Ok(trusted_layers) => {
                 debug!("Found trusted layers");
                 debug!("Verifying constraints");
+                info!("The bytecode image: {} is signed", image);
                 // TODO: Add some constraints here
                 let verification_constraints: VerificationConstraintVec = Vec::new();
                 verify_constraints(&trusted_layers, verification_constraints.iter())
@@ -90,7 +91,7 @@ impl CosignVerifier {
                     if !self.allow_unsigned {
                         bail!("Error triangulating image: {}", e);
                     } else {
-                        warn!("Unsigned image: {}", image);
+                        warn!("The bytecode image: {} is unsigned", image);
                         Ok(())
                     }
                 }

--- a/bpfd/src/oci_utils/image_manager.rs
+++ b/bpfd/src/oci_utils/image_manager.rs
@@ -11,7 +11,7 @@ use std::{
 use anyhow::Context;
 use bpfd_api::ImagePullPolicy;
 use flate2::read::GzDecoder;
-use log::{debug, info};
+use log::{debug, info, trace};
 use oci_distribution::{
     client::{ClientConfig, ClientProtocol},
     manifest,
@@ -262,7 +262,7 @@ impl ImageManager {
             .await
             .map_err(ImageError::ImageManifestPullFailure)?;
 
-        debug!("Raw container image manifest {}", image_manifest);
+        trace!("Raw container image manifest {}", image_manifest);
 
         let image_manifest_path = Path::new(&content_dir).join("manifest.json");
 
@@ -310,7 +310,7 @@ impl ImageManager {
             .map_err(|e| ImageError::ByteCodeImageProcessFailure(e.into()))?;
 
         let image_config: Value = serde_json::from_str(&config_contents).unwrap();
-        debug!("Raw container image config {}", image_config);
+        trace!("Raw container image config {}", image_config);
 
         // Deserialize image metadata(labels) from json config
         let image_labels: ContainerImageMetadata =

--- a/bpfd/src/utils.rs
+++ b/bpfd/src/utils.rs
@@ -52,7 +52,7 @@ pub(crate) async fn read_to_string<P: AsRef<Path>>(path: P) -> Result<String, Bp
 pub(crate) fn get_ifindex(iface: &str) -> Result<u32, BpfdError> {
     match if_nametoindex(iface) {
         Ok(index) => {
-            info!("Map {} to {}", iface, index);
+            debug!("Map {} to {}", iface, index);
             Ok(index)
         }
         Err(_) => {

--- a/docs/developer-guide/logging.md
+++ b/docs/developer-guide/logging.md
@@ -2,7 +2,7 @@
 
 This section describes how to enable logging in different `bpfd` deployments.
 
-## Local Privileged Process
+## Local Privileged Bpfd Process
 
 `bpfd` and `bpfctl` use the [env_logger](https://docs.rs/env_logger) crate to log messages to the terminal.
 By default, only `error` messages are logged, but that can be overwritten by setting
@@ -133,7 +133,7 @@ kubectl logs -n bpfd bpfd-daemon-dgqzw -c bpfd-agent
 
 #### Change Log Level
 
-To change the log level, edit the `bpfd-config` ConfigMap.
+To change the log level of the agent or daemon, edit the `bpfd-config` ConfigMap.
 The `bpfd-operator` will detect the change and restart the bpfd daemonset with the updated values.
 
 ```console
@@ -142,20 +142,15 @@ apiVersion: v1
 data:
   bpfd.agent.image: quay.io/bpfd/bpfd-agent:latest
   bpfd.image: quay.io/bpfd/bpfd:latest
-  bpfd.log.level: debug                 <==== Set bpfd-agent Log Level Here
+  bpfd.log.level: info                     <==== Set bpfd Log Level Here
+  bpfd.agent.log.level: info               <==== Set bpfd agent Log Level Here
   bpfd.toml: |
-    [tls] # REQUIRED
-    ca_cert = "/etc/bpfd/certs/ca/ca.crt"
-    cert = "/etc/bpfd/certs/bpfd/tls.crt"
-    key = "/etc/bpfd/certs/bpfd/tls.key"
-    client_cert = "/etc/bpfd/certs/bpfd-client/tls.crt"
-    client_key = "/etc/bpfd/certs/bpfd-client/tls.key"
+    [[grpc.endpoints]]
+    type = "unix"
+    path = "/bpfd-sock/bpfd.sock"
+    enabled = true
 kind: ConfigMap
 metadata:
-  annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"v1","data":{"bpfd.agent.image":"quay.io/bpfd/bpfd-agent:latest","bpfd.image":"quay.io/bpfd/bpfd:latest","bpfd.log.level":"debug","bpfd.na>
-                                                                              Set bpfd Log Level Here =========================================^^^^^
   creationTimestamp: "2023-05-05T14:41:19Z"
   name: bpfd-config
   namespace: bpfd
@@ -163,14 +158,22 @@ metadata:
   uid: 0cc04af4-032c-4712-b824-748b321d319b
 ```
 
-Valid values are:
+Valid values for the **daemon** (`bpfd.log.level`) are:
 
 * `error`
+* `warn`
 * `info`
 * `debug`
 * `trace`
 
-`trace` can be very verbose.
+`trace` can be very verbose. More information can be found regarding Rust's
+env_logger [here](https://docs.rs/env_logger/latest/env_logger/).
+
+Valid values for the **agent** (`bpfd.agent.log.level`) are:
+
+* `info`
+* `debug`
+* `trace`
 
 ### bpfd Operator
 


### PR DESCRIPTION
Try and fixup how are logging is organized a works

This is now the logs from a load and unload of two separate programs with `RUST_LOG=bpfd=info`.

```bash
---------------->>>>>>>>> STARTUP
[astoycos@nfvsdn-02-oot bpfd]$ sudo RUST_LOG=bpfd=info ./target/debug/bpfd
[INFO  bpfd] Log using env_logger
[INFO  bpfd] Has CAP_BPF: true
[INFO  bpfd] Has CAP_SYS_ADMIN: true
[WARN  bpfd] Unable to read config file, using defaults
[INFO  bpfd::certs] CA Certificate file /etc/bpfd/certs/ca/ca.pem does not exist. Creating CA Certificate.
[INFO  bpfd::certs] bpfd Certificate Key /etc/bpfd/certs/bpfd/bpfd.key does not exist. Creating bpfd Certificate.
[INFO  bpfd::certs] bpfd-client Certificate Key /etc/bpfd/certs/bpfd-client/bpfd-client.key does not exist. Creating bpfd-client Certificate.
[INFO  bpfd::oci_utils::cosign] Starting Cosign Verifier, downloading data from Sigstore TUF repository
[INFO  bpfd::serve] Listening on [::1]:50051
---------------->>>>>>>>> LOAD 1
[WARN  bpfd::oci_utils::cosign] The bytecode image: quay.io/bpfd-bytecode/xdp_pass:latest is unsigned
[INFO  bpfd::command] Loading program bytecode from container image: quay.io/bpfd-bytecode/xdp_pass:latest
[INFO  bpfd::bpf] Adding xdp program: pass
[INFO  bpfd::bpf] Removing program with id: 30845
---------------->>>>>>>>> LOAD 2
[WARN  bpfd::oci_utils::cosign] The bytecode image: quay.io/bpfd-bytecode/uprobe:latest is unsigned
[INFO  bpfd::command] Loading program bytecode from container image: quay.io/bpfd-bytecode/uprobe:latest
[INFO  bpfd::bpf] Adding probe program: my_uprobe
[INFO  bpfd::bpf] Removing program with id: 30846

```
All other commands intentionally don't log when at the info level. 

Additionally fix-up how we get and store the raw program bytes during the load process 