### PR TITLE
Fix the map_used_by field for managing the  map_pin_path

### DIFF
--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -43,6 +43,17 @@ shown below.
 export BPFD_IP_PREFIX="192.168.50"
 ```
 
+If bpfd logs are needed to help debug an integration test, set `RUST_LOG` either
+globally or for a given test.
+
+```bash
+export RUST_LOG=info
+```
+OR
+```bash
+RUST_LOG=info cargo xtask integration-test -- test_load_unload_xdp test_proceed_on_xdp
+```
+
 There are two categories of integration tests: basic and e2e.  The basic tests
 verify basic `bpfctl` functionality such as loading, listing, and unloading
 programs.  The e2e tests verify more advanced functionality such as the setting

--- a/docs/getting-started/bpfctl-guide.md
+++ b/docs/getting-started/bpfctl-guide.md
@@ -522,7 +522,7 @@ bpfctl get 6204
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6204
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6204
  Priority:      100
  Iface:         vethff657c7
  Position:      0

--- a/docs/getting-started/example-bpf-local.md
+++ b/docs/getting-started/example-bpf-local.md
@@ -369,7 +369,7 @@ bpfctl load-from-image --image-url quay.io/bpfd-bytecode/go-xdp-counter:latest x
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6229
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6229
  Priority:      50
  Iface:         ens3
  Position:      0

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -62,7 +62,7 @@ sudo ./target/debug/bpfctl load-from-image --image-url quay.io/bpfd-bytecode/xdp
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6213
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6213
  Priority:      100
  Iface:         vethff657c7
  Position:      0
@@ -109,7 +109,7 @@ sudo ./target/debug/bpfctl get 6213
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6213
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6213
  Priority:      100
  Iface:         vethff657c7
  Position:      0
@@ -150,7 +150,7 @@ sudo ./target/debug/bpfctl load-from-image --image-url quay.io/bpfd-bytecode/xdp
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6215
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6215
  Priority:      50
  Iface:         vethff657c7
  Position:      0
@@ -175,7 +175,7 @@ sudo ./target/debug/bpfctl load-from-image --image-url quay.io/bpfd-bytecode/xdp
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6217
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6217
  Priority:      200
  Iface:         vethff657c7
  Position:      2
@@ -280,7 +280,7 @@ sudo ./target/debug/bpfctl load-from-image --image-url quay.io/bpfd-bytecode/xdp
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6219
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6219
  Priority:      150
  Iface:         vethff657c7
  Position:      2
@@ -335,7 +335,7 @@ sudo ./target/debug/bpfctl list
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6215
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6215
  Priority:      50
  Iface:         vethff657c7
  Position:      0
@@ -360,7 +360,7 @@ sudo ./target/debug/bpfctl list
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6217
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6217
  Priority:      200
  Iface:         vethff657c7
  Position:      2
@@ -385,7 +385,7 @@ sudo ./target/debug/bpfctl list
  Metadata:      None
  Map Pin Path:  /run/bpfd/fs/maps/6219
  Map Owner ID:  None
- Map Used By:   None
+ Map Used By:   6219
  Priority:      150
  Iface:         vethff657c7
  Position:      1

--- a/tests/integration-test/src/tests/basic.rs
+++ b/tests/integration-test/src/tests/basic.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use assert_cmd::prelude::*;
 use bpfd_api::util::directories::{
-    BYTECODE_IMAGE_CONTENT_STORE, RTDIR_FS_TC_INGRESS, RTDIR_FS_XDP,
+    BYTECODE_IMAGE_CONTENT_STORE, RTDIR_FS_MAPS, RTDIR_FS_TC_INGRESS, RTDIR_FS_XDP,
 };
 use log::debug;
 use rand::Rng;
@@ -21,6 +21,60 @@ fn test_bpfctl_helptext() {
         .expect("bpfctl list --help failed")
         .stdout
         .is_empty());
+}
+
+#[integration_test]
+fn test_unix_socket_load_unload_xdp() {
+    let _namespace_guard = create_namespace().unwrap();
+    let _ping_guard = start_ping().unwrap();
+
+    cfgfile_append_unix_socket();
+
+    let _bpfd_guard = start_bpfd().unwrap();
+
+    assert!(iface_exists(DEFAULT_BPFD_IFACE));
+
+    debug!("Installing xdp_pass programs");
+
+    let globals = vec!["GLOBAL_u8=61", "GLOBAL_u32=0D0C0B0A"];
+
+    let proceed_on = vec![
+        "aborted",
+        "drop",
+        "pass",
+        "tx",
+        "redirect",
+        "dispatcher_return",
+    ];
+
+    let mut loaded_ids = vec![];
+    let mut rng = rand::thread_rng();
+
+    // Install a few xdp programs
+    for lt in LOAD_TYPES {
+        for _ in 0..5 {
+            let priority = rng.gen_range(1..255);
+            let (prog_id, _) = add_xdp(
+                DEFAULT_BPFD_IFACE,
+                priority,
+                Some(globals.clone()),
+                Some(proceed_on.clone()),
+                lt,
+                XDP_PASS_IMAGE_LOC,
+                XDP_PASS_FILE_LOC,
+                None, // metadata
+                None, // map_owner_id
+            );
+            loaded_ids.push(prog_id.unwrap());
+        }
+    }
+    assert_eq!(loaded_ids.len(), 10);
+
+    assert!(bpffs_has_entries(RTDIR_FS_XDP));
+
+    verify_and_delete_programs(loaded_ids);
+
+    cfgfile_remove();
 }
 
 #[integration_test]
@@ -59,7 +113,8 @@ fn test_load_unload_xdp() {
                 lt,
                 XDP_PASS_IMAGE_LOC,
                 XDP_PASS_FILE_LOC,
-                None,
+                None, // metadata
+                None, // map_owner_id
             );
             loaded_ids.push(prog_id.unwrap());
         }
@@ -75,6 +130,101 @@ fn test_load_unload_xdp() {
     verify_and_delete_programs(loaded_ids);
 
     assert!(!bpffs_has_entries(RTDIR_FS_XDP));
+}
+
+#[integration_test]
+fn test_map_sharing_load_unload_xdp() {
+    let _namespace_guard = create_namespace().unwrap();
+    let _ping_guard = start_ping().unwrap();
+    let _bpfd_guard = start_bpfd().unwrap();
+    let load_type = LoadType::Image;
+
+    assert!(iface_exists(DEFAULT_BPFD_IFACE));
+
+    // Load first program, which will own the map.
+    debug!("Installing xdp_counter map owner program");
+    let (map_owner_id, stdout_1) = add_xdp(
+        DEFAULT_BPFD_IFACE,
+        50,
+        None, // globals
+        None, // proceed_on
+        &load_type,
+        XDP_COUNTER_IMAGE_LOC,
+        "",   // file_path
+        None, // metadata
+        None, // map_owner_id
+    );
+    let binding_1 = stdout_1.unwrap();
+
+    // Verify "Map Used By:" field is set to only the just loaded program.
+    let map_used_by_1 = bpfctl_output_xdp_map_used_by(&binding_1);
+    assert!(map_used_by_1.len() == 1);
+    assert!(map_used_by_1[0] == *(map_owner_id.as_ref().unwrap()));
+
+    // Verify the "Map Owner Id:" is None.
+    let map_owner_id_1 = bpfctl_output_map_owner_id(&binding_1);
+    assert!(map_owner_id_1 == "None");
+
+    // Verify the "Map Pin Path:" is set properly.
+    let map_pin_path = RTDIR_FS_MAPS.to_string() + "/" + map_owner_id.as_ref().unwrap();
+    let map_pin_path_1 = bpfctl_output_map_pin_path(&binding_1);
+    assert!(map_pin_path_1 == map_pin_path);
+
+    // Load second program, which will share the map with the first program.
+    debug!("Installing xdp_counter map sharing program");
+    let map_owner_id_u32 = match map_owner_id.as_ref().unwrap().parse() {
+        Ok(v) => Some(v),
+        Err(_) => None,
+    };
+    let (shared_owner_id, stdout_2) = add_xdp(
+        DEFAULT_BPFD_IFACE,
+        50,
+        None, // globals
+        None, // proceed_on
+        &load_type,
+        XDP_COUNTER_IMAGE_LOC,
+        "",
+        None, // metadata
+        map_owner_id_u32,
+    );
+    let binding_2 = stdout_2.unwrap();
+
+    // Verify the "Map Used By:" field is set to both loaded program.
+    // Order of programs is not guarenteed.
+    let map_used_by_2 = bpfctl_output_xdp_map_used_by(&binding_2);
+    assert!(map_used_by_2.len() == 2);
+    assert!(
+        map_used_by_2[0] == *(map_owner_id.as_ref().unwrap())
+            || map_used_by_2[1] == *(map_owner_id.as_ref().unwrap())
+    );
+    assert!(
+        map_used_by_2[0] == *(shared_owner_id.as_ref().unwrap())
+            || map_used_by_2[1] == *(shared_owner_id.as_ref().unwrap())
+    );
+
+    // Verify the "Map Owner Id:" is set to map_owner_id.
+    let map_owner_id_2 = bpfctl_output_map_owner_id(&binding_2);
+    assert!(map_owner_id_2 == *(map_owner_id.as_ref().unwrap()));
+
+    // Verify the "Map Pin Path:" is set properly.
+    let map_pin_path_2 = bpfctl_output_map_pin_path(&binding_2);
+    assert!(map_pin_path_2 == map_pin_path);
+
+    // Unload the Map Owner Program
+    bpfd_del_program(&(map_owner_id.unwrap()));
+
+    // Retrive the Program sharing the map
+    let stdout_3 = bpfd_get(shared_owner_id.as_ref().unwrap());
+    let binding_3 = stdout_3.unwrap();
+
+    // Verify "Map Used By:" field is set to only the
+    // 2nd loaded program (one sharing the map).
+    let map_used_by_3 = bpfctl_output_xdp_map_used_by(&binding_3);
+    assert!(map_used_by_3.len() == 1);
+    assert!(map_used_by_3[0] == *(shared_owner_id.as_ref().unwrap()));
+
+    // Unload the Map Sharing Program
+    bpfd_del_program(&(shared_owner_id.unwrap()));
 }
 
 #[integration_test]
@@ -306,7 +456,8 @@ fn test_list_with_metadata() {
                 lt,
                 XDP_PASS_IMAGE_LOC,
                 XDP_PASS_FILE_LOC,
-                None,
+                None, // metadata
+                None, // map_owner_id
             );
             loaded_ids.push(prog_id.unwrap());
         }
@@ -323,6 +474,7 @@ fn test_list_with_metadata() {
         XDP_PASS_IMAGE_LOC,
         XDP_PASS_FILE_LOC,
         Some(vec![key]),
+        None, // map_owner_id
     );
     let id = prog_id.unwrap();
 


### PR DESCRIPTION
The map_used_by field is not being set properly. Each program should be listing the map it is using and all the other programs that are using it.