### PR TITLE
Map-sharing not working from k8s deployment

### DIFF
--- a/bpfd-operator/controllers/bpfd-agent/internal/bpfd-core.go
+++ b/bpfd-operator/controllers/bpfd-agent/internal/bpfd-core.go
@@ -156,7 +156,6 @@ func ListBpfdPrograms(ctx context.Context, bpfdClient gobpfd.BpfdClient, program
 }
 
 func GetBpfdProgram(ctx context.Context, bpfdClient gobpfd.BpfdClient, uuid types.UID) (*gobpfd.ListResponse_ListResult, error) {
-
 	listReq := gobpfd.ListRequest{
 		MatchMetadata: map[string]string{internal.UuidMetadataKey: string(uuid)},
 	}
@@ -167,7 +166,7 @@ func GetBpfdProgram(ctx context.Context, bpfdClient gobpfd.BpfdClient, uuid type
 	}
 
 	if len(listResponse.Results) != 1 {
-		return nil, fmt.Errorf("multible programs found for uuid: %+v ", uuid)
+		return nil, fmt.Errorf("multiple programs found for uuid: %+v ", uuid)
 	}
 
 	return listResponse.Results[0], nil

--- a/bpfd/src/rpc.rs
+++ b/bpfd/src/rpc.rs
@@ -248,7 +248,9 @@ impl Bpfd for BpfdLoader {
                         match r.data() {
                             // If filtering on `bpfd Only`, this program is of type Unsupported so skip
                             Err(_) => {
-                                if request.get_ref().bpfd_programs_only() {
+                                if request.get_ref().bpfd_programs_only()
+                                    || !request.get_ref().match_metadata.is_empty()
+                                {
                                     continue;
                                 }
                             }


### PR DESCRIPTION
Deploying BPF programs that share a map is not working in a K8s deployment. Running the examples in K8s:
```
cd bpfd/examples/
make deploy
```

See the program isn't loaded:
```
$ kubectl get xdpprograms -o yaml go-xdp-counter-sharing-map-example
apiVersion: bpfd.dev/v1alpha1
kind: XdpProgram
:
status:
  conditions:
  - lastTransitionTime: "2023-10-11T19:59:23Z"
    message: Waiting for Program Object to be reconciled to all nodes
    reason: ProgramsNotYetLoaded
    status: "True"
    type: NotYetLoaded
```

Logs:
```
2023-10-11T18:20:29Z	ERROR	xdp	Reconciling XdpProgram Failed	{"XdpProgramName": "go-xdp-counter-sharing-map-example", "ReconcileResult": "Requeue", "error": "failed to determine map owner: failed to get bpfd program for BpfProgram with UID 33443036-68e2-4879-920f-41a2ce371e1b: multible programs found for uuid: 33443036-68e2-4879-920f-41a2ce371e1b "}
github.com/bpfd-dev/bpfd/bpfd-operator/controllers/bpfd-agent.(*XdpProgramReconciler).Reconcile
	/usr/src/bpfd/bpfd-operator/controllers/bpfd-agent/xdp-program.go:184
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:323
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.1/pkg/internal/controller/controller.go:235
```

bpfd-agent is using a LIST call and filtering on metdata. The RPC code that performs the filtering was also returning non-bpfd created programs.