### PR TITLE
workspace-ified the netlink dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,14 @@ clap = { version = "4", default-features = false }
 comfy-table = { version = "7.1.0", default-features = false }
 env_logger = { version = "0.10", default-features = false }
 flate2 = { version = "1.0", default-features = false }
+futures = { version = "0.3.28", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 integration-test-macros = { path = "./tests/integration-test-macros" }
 inventory = { version = "0.3", default-features = false }
 itertools = { version = "0.11.0", default-features = false }
 lazy_static = { version = "1", default-features = false }
 log = { version = "0.4", default-features = false }
+netlink-packet-route = { version = "0.17.1", default-features = false }
 nix = { version = "0.27", default-features = false }
 oci-distribution = { version = "0.9", default-features = false }
 openssl = { version = "0.10.57", default-features = false }
@@ -44,6 +46,7 @@ prost-types = { version = "0.12.1", default-features = false }
 quote = { version = "1", default-features = false }
 rand = { version = "0.8", default-features = false }
 regex = { version = "1.9.6", default-features = false }
+rtnetlink = { version = "0.13.1", default-features = false }
 rustls = { version = "0.21.7", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1", default-features = false }

--- a/bpfd/Cargo.toml
+++ b/bpfd/Cargo.toml
@@ -22,9 +22,9 @@ chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "std"] }
 env_logger = { workspace = true }
 flate2 = { workspace = true, features = ["zlib"] }
-futures = "0.3.28"
+futures = { workspace = true }
 log = { workspace = true }
-netlink-packet-route = "0.17.1"
+netlink-packet-route = { workspace = true }
 nix = { workspace = true, features = [
     "fs",
     "mount",
@@ -38,7 +38,7 @@ oci-distribution = { workspace = true, default-features = false, features = [
     "trust-dns",
 ] }
 openssl = { workspace = true, features = ["vendored"] }
-rtnetlink = "0.13.1"
+rtnetlink = { workspace = true, features = ["tokio_socket"] }
 rustls = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }


### PR DESCRIPTION
Also added `features = ["tokio_socket"]` to `rtnetlink` in the bpfd `Cargo.toml` which became necessary after the title change.
