### PR TITLE
bpfd: fix release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,8 @@ jobs:
             perl \
             libssl-dev \
             gcc-multilib \
-            libelf-dev
+            libelf-dev \
+            musl-tools
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
add musl-tools to our github runers so we can build a static binary for our release artifacts.

https://github.com/bpfd-dev/bpfd/actions/runs/6961278822/job/18942543161